### PR TITLE
Give all primitives a deepPrint() extension function

### DIFF
--- a/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/DeepPrint.kt
+++ b/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/DeepPrint.kt
@@ -5,5 +5,3 @@ import kotlin.math.floor
 @Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.SOURCE)
 annotation class DeepPrint()
-
-fun <T> Array<T>.deepPrintContents(): String = this.toList().deepPrintContents()

--- a/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
+++ b/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
@@ -2,28 +2,52 @@ package com.bradyaiello.deepprint
 
 import kotlin.math.floor
 
+
+fun <T>deepPrintPrimitive(value: T): String {
+    return when (value) {
+        is String -> "\"$value\""
+        is Byte,
+        is Short,
+        is Int,
+        is Long,
+        is Double,
+        is Boolean -> "${value}"
+        is Char -> "'${value}'"
+        is Float -> "${value.formatForJS()}f"
+        else -> {
+            "$value"
+        }
+    }
+}
+
+fun String.deepPrint(): String = "\"$this\""
+
+fun Byte.deepPrint(): String = toString()
+
+fun Short.deepPrint(): String = toString()
+
+fun Int.deepPrint(): String = toString()
+
+fun Long.deepPrint(): String = toString()
+
+fun Double.deepPrint(): String = formatForJS()
+
+fun Boolean.deepPrint(): String = toString()
+
+fun Char.deepPrint(): String = "'${this}'"
+
+fun Float.deepPrint(): String = "${this.formatForJS()}f"
+
 fun <T> List<T>.deepPrintContents(): String {
     val stringBuilder = StringBuilder()
     this.forEach { value ->
-        val toAdd = when (value) {
-            is String -> "\"$value\","
-            is Byte,
-            is Short,
-            is Int,
-            is Long,
-            is Double,
-            is Boolean -> "${value},"
-
-            is Char -> "'${value}',"
-            is Float -> "${value}f,"
-            else -> {
-                value.toString()
-            }
-        }
-        stringBuilder.append(" $toAdd")
+        val toAdd = deepPrintPrimitive(value)
+        stringBuilder.append(" $toAdd,")
     }
     return stringBuilder.toString()
 }
+
+fun <T> Array<T>.deepPrintContents(): String = this.toList().deepPrintContents()
 
 /**
  * In jvm, android, and native platforms, printing 2.0f


### PR DESCRIPTION
Simplifying the primitive printing by moving logic out of the processor.