### PR TITLE
[Issue-2]Support maps (this PR is just primitives)

### DIFF
--- a/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
+++ b/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
@@ -11,12 +11,10 @@ fun <T>deepPrintPrimitive(value: T): String {
         is Int,
         is Long,
         is Double,
-        is Boolean -> "${value}"
+        is Boolean -> "$value"
         is Char -> "'${value}'"
         is Float -> "${value.formatForJS()}f"
-        else -> {
-            "$value"
-        }
+        else -> "$value"
     }
 }
 
@@ -37,6 +35,30 @@ fun Boolean.deepPrint(): String = toString()
 fun Char.deepPrint(): String = "'${this}'"
 
 fun Float.deepPrint(): String = "${this.formatForJS()}f"
+
+fun Int.indent(): String = " ".repeat(this)
+
+fun <K, V> Map<K, V>.deepPrint(
+    keyTransform: (K) -> String,
+    valueTransform: (V) -> String,
+    indent: Int = 4,
+): String {
+    val indentSpace = " ".repeat(indent)
+    return "mapOf(\n${deepPrintContents({indentSpace + keyTransform(it)},{valueTransform(it)})})"
+}
+
+fun <K, V> Map<K, V>.deepPrintContents(
+    keyTransform: (K) -> String,
+    valueTransform: (V) -> String,
+): String {
+    val stringBuilder = StringBuilder()
+    entries.forEach { (key, value) ->
+        val keyString = keyTransform(key)
+        val valueString = valueTransform(value)
+        stringBuilder.append("$keyString to $valueString,\n")
+    }
+    return stringBuilder.toString()
+}
 
 fun <T> List<T>.deepPrintContents(): String {
     val stringBuilder = StringBuilder()

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -5,12 +5,6 @@ import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 import com.module.external.ExternalDataClass
 
-// These test classes are in the commonMain source set because
-// commonTest is not supported for ksp. Individual targets work.
-// They're generated in target specific tasks kspIosX64Test,
-// kspJvmTest, etc. But there is no `kspCommonTestMetadata` task
-// for common test code.
-
 @DeepPrint
 data class SampleClass(val x: Float, val y: Float, val name: String)
 
@@ -27,6 +21,7 @@ data class ThreeDimCoordinate(
     val z: Float,
     val label: String
 )
+
 data class Name(val name: String)
 
 @DeepPrint
@@ -89,6 +84,12 @@ data class WithDeepPrintableArray(
 )
 
 @DeepPrint
+data class WithAMap(
+    val id: Long,
+    val someMap: Map<Int, String>
+)
+
+@DeepPrint
 data class WithAnnotatedProperty(
     val label: String,
     @property:DeepPrint
@@ -100,3 +101,7 @@ data class UsingUnannotatedDataClassFromExternalModule(
     val externalDataClass: ExternalDataClass,
     val id: String
 )
+
+data class SomeExternalClass(val name: String, val age: Int)
+
+data class MyClass(val externalClass: SomeExternalClass)

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -1,4 +1,6 @@
 package com.bradyaiello.deepprint.testobjects
+
+import com.bradyaiello.deepprint.DeepPrint
 import com.bradyaiello.deepprint.testclasses.AllTypes
 import com.bradyaiello.deepprint.testclasses.Name
 import com.bradyaiello.deepprint.testclasses.SampleClass
@@ -11,6 +13,7 @@ import com.bradyaiello.deepprint.testclasses.ThreeDimCoordinate
 import com.bradyaiello.deepprint.testclasses.ThreeDimLine
 import com.bradyaiello.deepprint.testclasses.Weather
 import com.bradyaiello.deepprint.testclasses.WithAList
+import com.bradyaiello.deepprint.testclasses.WithAMap
 import com.bradyaiello.deepprint.testclasses.WithAMutableList
 import com.bradyaiello.deepprint.testclasses.WithAnArray
 import com.bradyaiello.deepprint.testclasses.WithAnnotatedProperty
@@ -94,6 +97,10 @@ val withAnArray = WithAnArray(
     name = "some list",
     items = arrayOf<Int>(0, 1, 2, 3, 4)
 )
+
+val primitivesMap = mapOf(1 to "Hi", 2 to "By", 3 to "Aloha")
+
+val withAMap = WithAMap(123, primitivesMap)
 
 val withDeepPrintableList = WithDeepPrintableList("a name", listOf(surfer, surfer2))
 

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -3,10 +3,12 @@ package com.bradyaiello.deepprint
 import com.bradyaiello.deepprint.testclasses.deepPrint
 import com.bradyaiello.deepprint.testobjects.allTypes
 import com.bradyaiello.deepprint.testobjects.person
+import com.bradyaiello.deepprint.testobjects.primitivesMap
 import com.bradyaiello.deepprint.testobjects.sample
 import com.bradyaiello.deepprint.testobjects.threeDeep2Wide
 import com.bradyaiello.deepprint.testobjects.threeDimLine
 import com.bradyaiello.deepprint.testobjects.withAList
+import com.bradyaiello.deepprint.testobjects.withAMap
 import com.bradyaiello.deepprint.testobjects.withAMutableList
 import com.bradyaiello.deepprint.testobjects.withAnArray
 import com.bradyaiello.deepprint.testobjects.withAnnotatedProperty
@@ -19,7 +21,7 @@ import kotlin.test.assertEquals
 class BasicTest {
 
     @Test
-    fun primitives()    {
+    fun primitives() {
         val expected = """
             AllTypes(
               aString = "Hello",
@@ -109,17 +111,17 @@ class BasicTest {
         assertEquals(expected, actual)
     }
 
-   @Test
-   fun deepPrintableIntMutableList() {
-       val expected = """
-           WithAMutableList(
-             name = "some list",
-             items = mutableListOf<Int>( 0, 1, 2, 3, 4,),
-           )
-       """.trimIndent()
-       val actual = withAMutableList.deepPrint()
-       assertEquals(expected, actual)
-   }
+    @Test
+    fun deepPrintableIntMutableList() {
+        val expected = """
+            WithAMutableList(
+              name = "some list",
+              items = mutableListOf<Int>( 0, 1, 2, 3, 4,),
+            )
+        """.trimIndent()
+        val actual = withAMutableList.deepPrint()
+        assertEquals(expected, actual)
+    }
 
     @Test
     fun deepPrintableIntArray() {
@@ -262,11 +264,41 @@ class BasicTest {
         assertEquals(expected, actual)
     }
 
-/*  TODO(finish this test when external data classes supported)
     @Test
-    fun externalDataClass() {
-        val actual = usingUnannotatedDataClassFromExternalModule.deepPrint()
+    fun mapStandalonePrimitives() {
+        val expected = """
+            mapOf(
+              1 to "Hi",
+              2 to "By",
+              3 to "Aloha",
+            )
+        """.trimIndent()
+        val actual = primitivesMap.deepPrint( { it.deepPrint() }, { it.deepPrint() }, indent = 2)
         println(actual)
-    }*/
+        assertEquals(expected, actual)
+    }
 
+    @Test
+    fun withAMapPrimitives() {
+        val expected = """
+            WithAMap(
+              id = 123,
+              someMap = mapOf<Int,String>(
+                1 to "Hi",
+                2 to "By",
+                3 to "Aloha",
+              ),
+            )
+        """.trimIndent()
+        val actual = withAMap.deepPrint()
+        println(actual)
+        assertEquals(expected, actual)
+    }
+
+    /*  TODO(finish this test when external data classes supported)
+        @Test
+        fun externalDataClass() {
+            val actual = usingUnannotatedDataClassFromExternalModule.deepPrint()
+            println(actual)
+        }*/
 }

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -3,10 +3,12 @@ package com.bradyaiello.deepprint
 import com.bradyaiello.deepprint.testclasses.deepPrint
 import com.bradyaiello.deepprint.testobjects.allTypes
 import com.bradyaiello.deepprint.testobjects.person
+import com.bradyaiello.deepprint.testobjects.primitivesMap
 import com.bradyaiello.deepprint.testobjects.sample
 import com.bradyaiello.deepprint.testobjects.threeDeep2Wide
 import com.bradyaiello.deepprint.testobjects.threeDimLine
 import com.bradyaiello.deepprint.testobjects.withAList
+import com.bradyaiello.deepprint.testobjects.withAMap
 import com.bradyaiello.deepprint.testobjects.withAMutableList
 import com.bradyaiello.deepprint.testobjects.withAnArray
 import com.bradyaiello.deepprint.testobjects.withAnnotatedProperty
@@ -259,6 +261,37 @@ class BasicTest {
             )
         """.trimIndent()
         val actual = withAnnotatedProperty.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun mapStandalonePrimitives() {
+        val expected = """
+            mapOf(
+                1 to "Hi",
+                2 to "By",
+                3 to "Aloha",
+            )
+        """.trimIndent()
+        val actual = primitivesMap.deepPrint({it.deepPrint()}, {it.deepPrint()})
+        println(actual)
+        assertEquals(expected, actual)
+    }
+    
+    @Test
+    fun withAMapPrimitives() {
+        val expected = """
+            WithAMap(
+                id = 123,
+                someMap = mapOf<Int,String>(
+                    1 to "Hi",
+                    2 to "By",
+                    3 to "Aloha",
+                ),
+            )
+        """.trimIndent()
+        val actual = withAMap.deepPrint()
+        println(actual)
         assertEquals(expected, actual)
     }
 

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -83,6 +83,12 @@ data class WithDeepPrintableArray(
 )
 
 @DeepPrint
+data class WithAMap(
+    val id: Long,
+    val someMap: Map<Int, String>
+)
+
+@DeepPrint
 data class WithAnnotatedProperty(
     val label: String,
     @property:DeepPrint

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -1,4 +1,5 @@
 package com.bradyaiello.deepprint.testobjects
+import com.bradyaiello.deepprint.DeepPrint
 import com.bradyaiello.deepprint.testclasses.AllTypes
 import com.bradyaiello.deepprint.testclasses.Name
 import com.bradyaiello.deepprint.testclasses.SampleClass
@@ -11,6 +12,7 @@ import com.bradyaiello.deepprint.testclasses.ThreeDimCoordinate
 import com.bradyaiello.deepprint.testclasses.ThreeDimLine
 import com.bradyaiello.deepprint.testclasses.Weather
 import com.bradyaiello.deepprint.testclasses.WithAList
+import com.bradyaiello.deepprint.testclasses.WithAMap
 import com.bradyaiello.deepprint.testclasses.WithAMutableList
 import com.bradyaiello.deepprint.testclasses.WithAnArray
 import com.bradyaiello.deepprint.testclasses.WithAnnotatedProperty
@@ -94,6 +96,10 @@ val withAnArray = WithAnArray(
     name = "some list",
     items = arrayOf<Int>(0, 1, 2, 3, 4)
 )
+
+val primitivesMap = mapOf(1 to "Hi", 2 to "By", 3 to "Aloha")
+
+val withAMap = WithAMap(123, primitivesMap)
 
 val withDeepPrintableList = WithDeepPrintableList("a name", listOf(surfer, surfer2))
 


### PR DESCRIPTION
## Issue #2 
We should be able to print maps, both by themselves, and as a property in a data class.

## Fix
- Add map processing function
- Simplify by giving all primitives a deepPrint() extension function.
- Clean up by giving Int's an extension function toIndent() that returns a String of that many spaces

## Test
- Tested on JVM and KMP projects

### Have not yet:
- Tested mutable maps
- Added support for non-primitives as keys or values