### PR TITLE
Support maps with data class values

### DIFF
--- a/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
+++ b/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
@@ -18,23 +18,23 @@ fun <T>deepPrintPrimitive(value: T): String {
     }
 }
 
-fun String.deepPrint(): String = "\"$this\""
+fun String.deepPrint(indent: Int = 0): String = "${indent.indent()}\"$this\""
 
-fun Byte.deepPrint(): String = toString()
+fun Byte.deepPrint(indent: Int = 0): String = "${indent.indent()}$this"
 
-fun Short.deepPrint(): String = toString()
+fun Short.deepPrint(indent: Int = 0): String = "${indent.indent()}$this"
 
-fun Int.deepPrint(): String = toString()
+fun Int.deepPrint(indent: Int = 0): String = "${indent.indent()}$this"
 
-fun Long.deepPrint(): String = toString()
+fun Long.deepPrint(indent: Int = 0): String = "${indent.indent()}$this"
 
-fun Double.deepPrint(): String = formatForJS()
+fun Double.deepPrint(indent: Int = 0): String = "${indent.indent()}${formatForJS()}"
 
-fun Boolean.deepPrint(): String = toString()
+fun Boolean.deepPrint(indent: Int = 0): String = "${indent.indent()}$this"
 
-fun Char.deepPrint(): String = "'${this}'"
+fun Char.deepPrint(indent: Int = 0): String = "${indent.indent()}'${this}'"
 
-fun Float.deepPrint(): String = "${this.formatForJS()}f"
+fun Float.deepPrint(indent: Int = 0): String = "${indent.indent()}${formatForJS()}f"
 
 fun Int.indent(): String = " ".repeat(this)
 

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
@@ -38,6 +38,7 @@ import com.google.devtools.ksp.symbol.KSValueArgument
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Modifier.DATA
 import com.google.devtools.ksp.validate
 import java.io.OutputStream
 
@@ -116,14 +117,14 @@ class DeepPrintProcessor(
                 packageStringBuilder.append("package $packageName\n\n")
 
                 functionStringBuilder.append("\n")
-                functionStringBuilder.append("fun ${className}.deepPrint(indent: Int = 0): String {\n")
-                functionStringBuilder.append("val indentA = $indent\n")
+                functionStringBuilder.append("fun ${className}.deepPrint(currentIndent: Int = 0): String {\n")
+                functionStringBuilder.append("val indentWidth = $indent\n")
                 functionStringBuilder.append("return \"\"\"")
 
-                functionStringBuilder.append("\${\" \".repeat(indent)}$className(\n")
+                functionStringBuilder.append("\${currentIndent.indent()}$className(\n")
                 props.forEach { propertyDeclaration ->
                     val type: KSType = propertyDeclaration.type.resolve()
-                    functionStringBuilder.append("\${\" \".repeat(indent + indentA)}${propertyDeclaration} = ")
+                    functionStringBuilder.append("\${(currentIndent + indentWidth).indent()}${propertyDeclaration} = ")
                     val propertyAssignment = when (type.declaration.simpleName.asString()) {
                         "String", "Byte", "Short", "Int", "Long", "Boolean", "Char",
                         "Double", "Float" -> "\${${propertyDeclaration}.deepPrint()},\n"
@@ -141,8 +142,7 @@ class DeepPrintProcessor(
                     }
                     functionStringBuilder.append(propertyAssignment)
                 }
-                functionStringBuilder.append("\${indent.indent()})")
-                //functionStringBuilder.append("\${\" \".repeat(indent)})")
+                functionStringBuilder.append("\${currentIndent.indent()})")
                 functionStringBuilder.append("\"\"\"\n}")
                 functionStringBuilder.append("\n")
             }
@@ -167,7 +167,7 @@ class DeepPrintProcessor(
                         propertyDeclaration.isAnnotationPresent(DeepPrint::class))
             ) {
                 importsStringBuilder.append("import $propPackageName.deepPrint\n")
-                "\n\${${propertyDeclaration}.deepPrint(indent + indentA + indentA)},\n"
+                "\n\${${propertyDeclaration}.deepPrint(currentIndent + 2 * indentWidth)},\n"
             } else { /* no annotation on property or class */
                 "\$$propertyDeclaration,\n"
             }
@@ -186,10 +186,10 @@ class DeepPrintProcessor(
                 else  -> "mutableMapOf"
             }
             val opening = "$mapConstructor<$ksKeyTypeRef,$ksValueTypeRef>(\n"
-
-            // myMap.deepPrintContents({ it.deepPrint() }, { it.deepPrint() }
-            val entriesPrint =  "\${${propertyDeclaration}.deepPrintContents({(indent + 2 * indentA).indent() + " +
-                    "it.deepPrint() }, { it.deepPrint()})}\${(indent + indentA).indent()}),\n"
+            val valueTransform = if (ksValueTypeRef.isDataClass()) "it.deepPrint(currentIndent + 2 * indentWidth)" 
+                else "it.deepPrint()"
+            val entriesPrint =  "\${${propertyDeclaration}.deepPrintContents({(currentIndent + 2 * indentWidth).indent() + " +
+                    "it.deepPrint() }, { $valueTransform })}\${(currentIndent + indentWidth).indent()}),\n"
             return opening + entriesPrint
         }
 
@@ -216,9 +216,9 @@ class DeepPrintProcessor(
             }
             val opening = "$listConstructor<${listType}>("
             val itemsPrint: String = if (paramHasDeepPrintAnnotation) {
-                "\n\${$propertyDeclaration.map{ it.deepPrint(indent = " +
-                        "indent + indentA + indentA) +\",\\n\"}" +
-                        ".reduce {acc, item -> acc + item}}\${\" \".repeat(indent + indentA)}),\n"
+                "\n\${$propertyDeclaration.map{ it.deepPrint(currentIndent = " +
+                        "currentIndent + 2 * indentWidth) +\",\\n\"}" +
+                        ".reduce {acc, item -> acc + item}}\${(currentIndent + indentWidth).indent()}),\n"
             } else {
                 "\${$propertyDeclaration.deepPrintContents()}),\n"
             }
@@ -226,6 +226,8 @@ class DeepPrintProcessor(
         }
         
         private fun KSClassDeclaration.isDataClass() = modifiers.contains(Modifier.DATA)
+        private fun KSTypeReference.isDataClass() = modifiers.contains(Modifier.DATA)
+
         override fun visitAnnotated(annotated: KSAnnotated, data: Unit) = ""
         override fun visitAnnotation(annotation: KSAnnotation, data: Unit) = ""
         override fun visitCallableReference(reference: KSCallableReference, data: Unit) = ""
@@ -272,4 +274,3 @@ class DeepPrintProcessor(
     }
     
  }
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,6 @@
 # suppress inspection "UnusedProperty" for whole file
 kotlin.code.style=official
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g
+
 version=0.1.0-alpha

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -90,6 +90,12 @@ data class WithAMap(
 )
 
 @DeepPrint
+data class WithMapDataClasses(
+    val id: Long,
+    val someMap: Map<Int, Surfer>
+)
+
+@DeepPrint
 data class WithAnnotatedProperty(
     val label: String,
     @property:DeepPrint

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -90,9 +90,21 @@ data class WithAMap(
 )
 
 @DeepPrint
+data class WithAMutableMap(
+    val id: Long,
+    val someMutableMap: MutableMap<Int, String>
+)
+
+@DeepPrint
 data class WithMapDataClasses(
     val id: Long,
     val someMap: Map<Int, Surfer>
+)
+
+@DeepPrint
+data class WithMutableMapDataClasses(
+    val id: Long,
+    val someMutableMap: MutableMap<Int, Surfer>
 )
 
 @DeepPrint

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -1,6 +1,5 @@
 package com.bradyaiello.deepprint.testobjects
 
-import com.bradyaiello.deepprint.DeepPrint
 import com.bradyaiello.deepprint.testclasses.AllTypes
 import com.bradyaiello.deepprint.testclasses.Name
 import com.bradyaiello.deepprint.testclasses.SampleClass
@@ -20,6 +19,7 @@ import com.bradyaiello.deepprint.testclasses.WithAnnotatedProperty
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableArray
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
+import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 
@@ -101,6 +101,13 @@ val withAnArray = WithAnArray(
 val primitivesMap = mapOf(1 to "Hi", 2 to "By", 3 to "Aloha")
 
 val withAMap = WithAMap(123, primitivesMap)
+
+val classesMap = mapOf(1 to surfer, 2 to surfer2)
+
+val withAMapDataClasses = WithMapDataClasses(
+    id = 204,
+    someMap = classesMap
+)
 
 val withDeepPrintableList = WithDeepPrintableList("a name", listOf(surfer, surfer2))
 

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -14,12 +14,14 @@ import com.bradyaiello.deepprint.testclasses.Weather
 import com.bradyaiello.deepprint.testclasses.WithAList
 import com.bradyaiello.deepprint.testclasses.WithAMap
 import com.bradyaiello.deepprint.testclasses.WithAMutableList
+import com.bradyaiello.deepprint.testclasses.WithAMutableMap
 import com.bradyaiello.deepprint.testclasses.WithAnArray
 import com.bradyaiello.deepprint.testclasses.WithAnnotatedProperty
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableArray
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
+import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 
@@ -99,14 +101,22 @@ val withAnArray = WithAnArray(
 )
 
 val primitivesMap = mapOf(1 to "Hi", 2 to "By", 3 to "Aloha")
+val primitivesMutableMap = mutableMapOf(1 to "Hi", 2 to "By", 3 to "Aloha")
 
 val withAMap = WithAMap(123, primitivesMap)
+val withAMutableMap = WithAMutableMap(123, primitivesMutableMap)
 
 val classesMap = mapOf(1 to surfer, 2 to surfer2)
+val classesMutableMap = mutableMapOf(1 to surfer, 2 to surfer2)
 
 val withAMapDataClasses = WithMapDataClasses(
     id = 204,
     someMap = classesMap
+)
+
+val withAMutableMapDataClasses = WithMutableMapDataClasses(
+    id = 204,
+    someMutableMap = classesMutableMap
 )
 
 val withDeepPrintableList = WithDeepPrintableList("a name", listOf(surfer, surfer2))

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -9,7 +9,10 @@ import com.bradyaiello.deepprint.testobjects.threeDeep2Wide
 import com.bradyaiello.deepprint.testobjects.threeDimLine
 import com.bradyaiello.deepprint.testobjects.withAList
 import com.bradyaiello.deepprint.testobjects.withAMap
+import com.bradyaiello.deepprint.testobjects.withAMapDataClasses
 import com.bradyaiello.deepprint.testobjects.withAMutableList
+import com.bradyaiello.deepprint.testobjects.withAMutableMap
+import com.bradyaiello.deepprint.testobjects.withAMutableMapDataClasses
 import com.bradyaiello.deepprint.testobjects.withAnArray
 import com.bradyaiello.deepprint.testobjects.withAnnotatedProperty
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableArray
@@ -295,6 +298,87 @@ class BasicTest {
         assertEquals(expected, actual)
     }
 
+    @Test
+    fun withAMapWithDataClasses() {
+        val expected = """
+            WithMapDataClasses(
+              id = 204,
+              someMap = mapOf<Int,Surfer>(
+                1 to 
+                  Surfer(
+                    name = "Honolua Blomfield",
+                    surfboard = 
+                      Surfboard(
+                        length = 11.5f,
+                        width = 2.0f,
+                        style = "longboard",
+                      ),
+                  ),
+                2 to 
+                  Surfer(
+                    name = "Kelly Slater",
+                    surfboard = 
+                      Surfboard(
+                        length = 5.9f,
+                        width = 1.8f,
+                        style = "shortboard",
+                      ),
+                  ),
+              ),
+            )
+        """.trimIndent()
+        val actual = withAMapDataClasses.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun withAMutableMapPrimitives() {
+        val expected = """
+            WithAMutableMap(
+              id = 123,
+              someMutableMap = mutableMapOf<Int,String>(
+                1 to "Hi",
+                2 to "By",
+                3 to "Aloha",
+              ),
+            )
+        """.trimIndent()
+        val actual = withAMutableMap.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun withAMutableMapWithDataClasses() {
+        val expected = """
+            WithMutableMapDataClasses(
+              id = 204,
+              someMutableMap = mutableMapOf<Int,Surfer>(
+                1 to 
+                  Surfer(
+                    name = "Honolua Blomfield",
+                    surfboard = 
+                      Surfboard(
+                        length = 11.5f,
+                        width = 2.0f,
+                        style = "longboard",
+                      ),
+                  ),
+                2 to 
+                  Surfer(
+                    name = "Kelly Slater",
+                    surfboard = 
+                      Surfboard(
+                        length = 5.9f,
+                        width = 1.8f,
+                        style = "shortboard",
+                      ),
+                  ),
+              ),
+            )
+        """.trimIndent()
+        val actual = withAMutableMapDataClasses.deepPrint()
+        assertEquals(expected, actual)
+    }
     /*  TODO(finish this test when external data classes supported)
         @Test
         fun externalDataClass() {

--- a/test-project/build.gradle.kts
+++ b/test-project/build.gradle.kts
@@ -29,14 +29,10 @@ kotlin.sourceSets {
     }
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
-
 dependencies {
     implementation(project(":deep-print-annotations"))
     implementation(project(":deep-print-processor"))
     ksp(project(":deep-print-processor"))
     implementation(project(":external-module"))
-    testImplementation(Testing.Junit.jupiter)
+    testImplementation(kotlin("test"))
 }

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -291,7 +291,6 @@ class BasicTest {
             )
         """.trimIndent()
         val actual = withAMap.deepPrint()
-        println(actual)
         assertEquals(expected, actual)
     }
 

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -11,13 +11,15 @@ import com.bradyaiello.deepprint.testobjects.withAList
 import com.bradyaiello.deepprint.testobjects.withAMap
 import com.bradyaiello.deepprint.testobjects.withAMapDataClasses
 import com.bradyaiello.deepprint.testobjects.withAMutableList
+import com.bradyaiello.deepprint.testobjects.withAMutableMap
+import com.bradyaiello.deepprint.testobjects.withAMutableMapDataClasses
 import com.bradyaiello.deepprint.testobjects.withAnArray
 import com.bradyaiello.deepprint.testobjects.withAnnotatedProperty
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableArray
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableList
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class BasicTest {
 
@@ -275,7 +277,6 @@ class BasicTest {
             )
         """.trimIndent()
         val actual = primitivesMap.deepPrint({it.deepPrint()}, {it.deepPrint()})
-        println(actual)
         assertEquals(expected, actual)
     }
     
@@ -326,13 +327,60 @@ class BasicTest {
         """.trimIndent()
         val actual = withAMapDataClasses.deepPrint()
         assertEquals(expected, actual)
-        println(actual)
     }
 
-/*  TODO(finish this test when external data classes supported)
     @Test
-    fun externalDataClass() {
-        val actual = usingUnannotatedDataClassFromExternalModule.deepPrint()
-        println(actual)
-    }*/
+    fun withAMutableMapPrimitives() {
+        val expected = """
+            WithAMutableMap(
+                id = 123,
+                someMutableMap = mutableMapOf<Int,String>(
+                    1 to "Hi",
+                    2 to "By",
+                    3 to "Aloha",
+                ),
+            )
+        """.trimIndent()
+        val actual = withAMutableMap.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun withAMutableMapWithDataClasses() {
+        val expected = """
+            WithMutableMapDataClasses(
+                id = 204,
+                someMutableMap = mutableMapOf<Int,Surfer>(
+                    1 to 
+                        Surfer(
+                            name = "Honolua Blomfield",
+                            surfboard = 
+                                Surfboard(
+                                    length = 11.5f,
+                                    width = 2.0f,
+                                    style = "longboard",
+                                ),
+                        ),
+                    2 to 
+                        Surfer(
+                            name = "Kelly Slater",
+                            surfboard = 
+                                Surfboard(
+                                    length = 5.9f,
+                                    width = 1.8f,
+                                    style = "shortboard",
+                                ),
+                        ),
+                ),
+            )
+        """.trimIndent()
+        val actual = withAMutableMapDataClasses.deepPrint()
+        assertEquals(expected, actual)
+    }
+    /*  TODO(finish this test when external data classes supported)
+        @Test
+        fun externalDataClass() {
+            val actual = usingUnannotatedDataClassFromExternalModule.deepPrint()
+            println(actual)
+        }*/
 }

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -9,6 +9,7 @@ import com.bradyaiello.deepprint.testobjects.threeDeep2Wide
 import com.bradyaiello.deepprint.testobjects.threeDimLine
 import com.bradyaiello.deepprint.testobjects.withAList
 import com.bradyaiello.deepprint.testobjects.withAMap
+import com.bradyaiello.deepprint.testobjects.withAMapDataClasses
 import com.bradyaiello.deepprint.testobjects.withAMutableList
 import com.bradyaiello.deepprint.testobjects.withAnArray
 import com.bradyaiello.deepprint.testobjects.withAnnotatedProperty
@@ -292,6 +293,40 @@ class BasicTest {
         """.trimIndent()
         val actual = withAMap.deepPrint()
         assertEquals(expected, actual)
+    }
+    
+    @Test
+    fun withAMapWithDataClasses() {
+        val expected = """
+            WithMapDataClasses(
+                id = 204,
+                someMap = mapOf<Int,Surfer>(
+                    1 to 
+                        Surfer(
+                            name = "Honolua Blomfield",
+                            surfboard = 
+                                Surfboard(
+                                    length = 11.5f,
+                                    width = 2.0f,
+                                    style = "longboard",
+                                ),
+                        ),
+                    2 to 
+                        Surfer(
+                            name = "Kelly Slater",
+                            surfboard = 
+                                Surfboard(
+                                    length = 5.9f,
+                                    width = 1.8f,
+                                    style = "shortboard",
+                                ),
+                        ),
+                ),
+            )
+        """.trimIndent()
+        val actual = withAMapDataClasses.deepPrint()
+        assertEquals(expected, actual)
+        println(actual)
     }
 
 /*  TODO(finish this test when external data classes supported)

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -89,9 +89,21 @@ data class WithAMap(
 )
 
 @DeepPrint
+data class WithAMutableMap(
+    val id: Long,
+    val someMutableMap: MutableMap<Int, String>
+)
+
+@DeepPrint
 data class WithMapDataClasses(
     val id: Long,
     val someMap: Map<Int, Surfer>
+)
+
+@DeepPrint
+data class WithMutableMapDataClasses(
+    val id: Long,
+    val someMutableMap: MutableMap<Int, Surfer>
 )
 
 @DeepPrint

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -89,6 +89,12 @@ data class WithAMap(
 )
 
 @DeepPrint
+data class WithMapDataClasses(
+    val id: Long,
+    val someMap: Map<Int, Surfer>
+)
+
+@DeepPrint
 data class WithAnnotatedProperty(
     val label: String,
     @property:DeepPrint

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -1,5 +1,4 @@
 package com.bradyaiello.deepprint.testobjects
-import com.bradyaiello.deepprint.DeepPrint
 import com.bradyaiello.deepprint.testclasses.AllTypes
 import com.bradyaiello.deepprint.testclasses.Name
 import com.bradyaiello.deepprint.testclasses.SampleClass
@@ -19,6 +18,7 @@ import com.bradyaiello.deepprint.testclasses.WithAnnotatedProperty
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableArray
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
+import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 
@@ -101,6 +101,13 @@ val primitivesMap = mapOf(1 to "Hi", 2 to "By", 3 to "Aloha")
 
 val withAMap = WithAMap(123, primitivesMap)
 
+val classesMap = mapOf(1 to surfer, 2 to surfer2)
+
+val withAMapDataClasses = WithMapDataClasses(
+    id = 204,
+    someMap = classesMap
+)
+
 val withDeepPrintableList = WithDeepPrintableList("a name", listOf(surfer, surfer2))
 
 val withDeepPrintableMutableList = WithDeepPrintableMutableList("a name", mutableListOf(surfer, surfer2))
@@ -122,3 +129,4 @@ val usingUnannotatedDataClassFromExternalModule = UsingUnannotatedDataClassFromE
     id = "985270457834522"
 )
 */
+

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -1,4 +1,5 @@
 package com.bradyaiello.deepprint.testobjects
+
 import com.bradyaiello.deepprint.testclasses.AllTypes
 import com.bradyaiello.deepprint.testclasses.Name
 import com.bradyaiello.deepprint.testclasses.SampleClass
@@ -13,12 +14,14 @@ import com.bradyaiello.deepprint.testclasses.Weather
 import com.bradyaiello.deepprint.testclasses.WithAList
 import com.bradyaiello.deepprint.testclasses.WithAMap
 import com.bradyaiello.deepprint.testclasses.WithAMutableList
+import com.bradyaiello.deepprint.testclasses.WithAMutableMap
 import com.bradyaiello.deepprint.testclasses.WithAnArray
 import com.bradyaiello.deepprint.testclasses.WithAnnotatedProperty
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableArray
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
+import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 
@@ -98,14 +101,22 @@ val withAnArray = WithAnArray(
 )
 
 val primitivesMap = mapOf(1 to "Hi", 2 to "By", 3 to "Aloha")
+val primitivesMutableMap = mutableMapOf(1 to "Hi", 2 to "By", 3 to "Aloha")
 
 val withAMap = WithAMap(123, primitivesMap)
+val withAMutableMap = WithAMutableMap(123, primitivesMutableMap)
 
 val classesMap = mapOf(1 to surfer, 2 to surfer2)
+val classesMutableMap = mutableMapOf(1 to surfer, 2 to surfer2)
 
 val withAMapDataClasses = WithMapDataClasses(
     id = 204,
     someMap = classesMap
+)
+
+val withAMutableMapDataClasses = WithMutableMapDataClasses(
+    id = 204,
+    someMutableMap = classesMutableMap
 )
 
 val withDeepPrintableList = WithDeepPrintableList("a name", listOf(surfer, surfer2))
@@ -129,4 +140,3 @@ val usingUnannotatedDataClassFromExternalModule = UsingUnannotatedDataClassFromE
     id = "985270457834522"
 )
 */
-


### PR DESCRIPTION
[Issue-2] Support maps (data class values)
#2 

## Issue
We should be able to print maps, where data classes comprise the values.

## Fix
- Add support for data classes as values
- Play around with indentation so it looks good for both data classes and primitives.

## Test
- Tested on JVM and KMP projects

Have not yet:
- Tested mutable maps