### PR TITLE
Reflection: Map and MutableMap

### DIFF
--- a/.github/workflows/test_apple.yml
+++ b/.github/workflows/test_apple.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
-      - "reflection/**"
+      - "deep-print-reflection/**"
 
 jobs:
   build:

--- a/.github/workflows/test_jvm_js_linux.yml
+++ b/.github/workflows/test_jvm_js_linux.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
-      - "reflection/**"
+      - "deep-print-reflection/**"
 
 jobs:
   build:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
-      - "reflection/**"
+      - "deep-print-reflection/**"
 
 jobs:
   build:

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectList.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectList.kt
@@ -1,0 +1,52 @@
+package com.bradyaiello.deepprint
+
+fun <T> List<T>.deepPrintListReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "listOf",
+    standalone: Boolean = true,
+): String {
+    val stringBuilder = StringBuilder()
+    val start = startingIndent.indent()
+    val prefix = if (standalone) start else " "
+    stringBuilder.append("${prefix}$constructor(\n")
+    this.forEach { value ->
+        value.deepPrintListItem(stringBuilder, startingIndent, indentSize)
+    }
+    stringBuilder.append("${start})")
+    return stringBuilder.toString()
+}
+
+fun <T> MutableList<T>.deepPrintMutableListReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    standalone: Boolean = true,
+): String {
+    return this.deepPrintListReflection(
+        startingIndent = startingIndent,
+        indentSize = indentSize,
+        constructor = "mutableListOf",
+        standalone = standalone,
+    )
+}
+
+internal fun <Any> Any?.deepPrintListItem(
+    stringBuilder: StringBuilder,
+    startingIndent: Int,
+    indentSize: Int
+) {
+    val totalIndent = startingIndent.indent() + indentSize.indent()
+
+    if (this == null) {
+        stringBuilder.append("${totalIndent}null,\n")
+    } else if (this!!::class.isPrimitive()) {
+        stringBuilder.append("${totalIndent}${deepPrintPrimitive(this)},\n")
+    } else {
+        stringBuilder.append(
+            this.deepPrintReflection(
+                initialIndentLength = startingIndent + indentSize,
+                indentIncrementLength = indentSize,
+            ) + "\n"
+        )
+    }
+}

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectMap.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectMap.kt
@@ -1,0 +1,83 @@
+package com.bradyaiello.deepprint
+
+fun <K, V> MutableMap<K, V>.deepPrintMutableMapReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "mutableMapOf",
+    standalone: Boolean = true,
+): String {
+    return deepPrintMapReflection(
+        startingIndent,
+        indentSize,
+        constructor,
+        standalone,
+    )
+}
+
+
+fun <K, V> Map<K, V>.deepPrintMapReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "mapOf",
+    standalone: Boolean = true,
+): String {
+    val stringBuilder = StringBuilder()
+    val start = startingIndent.indent()
+    val prefix = if (standalone) start else " "
+    stringBuilder.append("${prefix}$constructor(\n")
+
+    this.forEach { entry ->
+        entry.deepPrintMapEntryReflection(
+            stringBuilder = stringBuilder,
+            startingIndent = startingIndent,
+            indentSize = indentSize,
+        )
+    }
+    stringBuilder.append("${start})")
+    return stringBuilder.toString()
+}
+
+private fun <Any> Any?.deepPrintMapKeyOrValue(
+    stringBuilder: StringBuilder,
+    startingIndent: Int,
+    indentSize: Int
+) {
+    val totalIndent = startingIndent.indent() + indentSize.indent()
+
+    if (this == null) {
+        stringBuilder.append("${totalIndent}null")
+    } else if (this!!::class.isPrimitive()) {
+        stringBuilder.append("${totalIndent}${deepPrintPrimitive(this)}")
+    } else {
+        stringBuilder.append(
+            this.deepPrintReflection(
+                initialIndentLength = startingIndent + indentSize,
+                indentIncrementLength = indentSize,
+            )
+        )
+    }
+}
+
+private fun <K, V> Map.Entry<K, V?>.deepPrintMapEntryReflection(
+    stringBuilder: StringBuilder,
+    startingIndent: Int,
+    indentSize: Int,
+) {
+    key.deepPrintMapKeyOrValue(
+        stringBuilder = stringBuilder,
+        startingIndent = startingIndent,
+        indentSize = indentSize
+    )
+    val singleLine = key!!.isPrimitive() && ((value == null) || value!!.isPrimitive())
+    val toStr = if (singleLine) " to " else " to\n"
+    stringBuilder.append(toStr)
+    val newStartingIndent = if (singleLine) 0 else startingIndent + indentSize
+    val newIndentSize = if (singleLine) 0 else indentSize
+    value.deepPrintMapKeyOrValue(
+        stringBuilder = stringBuilder,
+        startingIndent = newStartingIndent,
+        indentSize = newIndentSize
+    )
+    val suffix = if (singleLine) ",\n" else "\n"
+    stringBuilder.append(suffix)
+}

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
@@ -7,15 +7,15 @@ import kotlin.reflect.full.memberProperties
 fun Any?.deepPrintReflection(
     initialIndentLength: Int = 0,
     indentIncrementLength: Int = 4,
-) : String {
+): String {
     if (this == null || !this::class.isData) {
         return ""
     }
     val kClass = this::class
-    
+
     val initialIndent = if (initialIndentLength == 0) ""
     else initialIndentLength.indent()
-    
+
     val indentIncrement = indentIncrementLength.indent()
 
     val builder = StringBuilder()
@@ -24,12 +24,12 @@ fun Any?.deepPrintReflection(
     builder.append("$initialIndent$constructorCall")
     val params = constructor.parameters
 
-    params.forEach { kParam -> 
+    params.forEach { kParam ->
         val propName = kParam.name
         val propValue = this.getPropertyValue(kParam)!!
         if (propValue::class.isPrimitive()) {
             builder.append("$initialIndent$indentIncrement$propName = ${deepPrintPrimitive(propValue)},\n")
-        }  else if (propValue is List<*>) {
+        } else if (propValue is List<*>) {
             /*
                 List and MutableList look identical at runtime. 
                 They both are implemented by Java Arraylist.
@@ -40,7 +40,7 @@ fun Any?.deepPrintReflection(
              */
             builder.append(
                 "$initialIndent$indentIncrement$propName = ${
-                    propValue.deepPrintListReflect(
+                    propValue.deepPrintListReflection(
                         startingIndent = initialIndentLength + indentIncrementLength,
                         indentSize = indentIncrementLength,
                         standalone = false,
@@ -51,7 +51,7 @@ fun Any?.deepPrintReflection(
         } else {
             builder.append(
                 propValue.deepPrintReflection(
-                    initialIndentLength = initialIndentLength + indentIncrementLength, 
+                    initialIndentLength = initialIndentLength + indentIncrementLength,
                     indentIncrementLength = indentIncrementLength,
                 )
             )
@@ -65,8 +65,6 @@ fun Any?.deepPrintReflection(
     return builder.toString()
 }
 
-
-
 private fun Any.getPropertyValue(kParam: KParameter): Any? {
     return javaClass
         .kotlin
@@ -74,7 +72,7 @@ private fun Any.getPropertyValue(kParam: KParameter): Any? {
         .first { prop -> prop.name == kParam.name }.get(this)
 }
 
-fun <T : Any>KClass<T>.isPrimitive(): Boolean {
+fun <T : Any> KClass<T>.isPrimitive(): Boolean {
     return when (this) {
         Byte::class,
         Char::class,
@@ -89,12 +87,27 @@ fun <T : Any>KClass<T>.isPrimitive(): Boolean {
     }
 }
 
-fun <T> MutableList<T>.deepPrintMutableListReflect(
+fun Any.isPrimitive(): Boolean {
+    return when (this) {
+        is Byte,
+        is Char,
+        is String,
+        is Boolean,
+        is Short,
+        is Int,
+        is Long,
+        is Float,
+        is Double -> true
+        else -> false
+    }
+}
+
+fun <T> MutableList<T>.deepPrintMutableListReflection(
     startingIndent: Int = 0,
     indentSize: Int = 4,
     standalone: Boolean = true,
 ): String {
-    return this.deepPrintListReflect(
+    return this.deepPrintListReflection(
         startingIndent = startingIndent,
         indentSize = indentSize,
         constructor = "mutableListOf",
@@ -102,7 +115,7 @@ fun <T> MutableList<T>.deepPrintMutableListReflect(
     )
 }
 
-fun <T> List<T>.deepPrintListReflect(
+fun <T> List<T>.deepPrintListReflection(
     startingIndent: Int = 0,
     indentSize: Int = 4,
     constructor: String = "listOf",
@@ -110,24 +123,114 @@ fun <T> List<T>.deepPrintListReflect(
 ): String {
     val stringBuilder = StringBuilder()
     val start = startingIndent.indent()
-    val indent = indentSize.indent()
     val prefix = if (standalone) start else " "
     stringBuilder.append("${prefix}$constructor(\n")
-    val totalIndent = start + indent
     this.forEach { value ->
-        if (value == null) {
-            stringBuilder.append("${totalIndent}null,\n")
-        } else if (value!!::class.isPrimitive()) {
-            stringBuilder.append("${totalIndent}${deepPrintPrimitive(value)},\n")
-        } else {
-            stringBuilder.append(
-                value.deepPrintReflection(
-                    initialIndentLength = startingIndent + indentSize,
-                    indentIncrementLength = indentSize,
-                ) + "\n"
-            )
-        }
+        value.deepPrintListItem(stringBuilder, startingIndent, indentSize)
     }
     stringBuilder.append("${start})")
     return stringBuilder.toString()
+}
+
+fun <K, V> MutableMap<K, V>.deepPrintMutableMapReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "mutableMapOf",
+    standalone: Boolean = true,
+): String {
+    return deepPrintMapReflection(
+        startingIndent, 
+        indentSize, 
+        constructor, 
+        standalone,
+    )
+}
+
+
+fun <K, V> Map<K, V>.deepPrintMapReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "mapOf",
+    standalone: Boolean = true,
+): String {
+    val stringBuilder = StringBuilder()
+    val start = startingIndent.indent()
+    val prefix = if (standalone) start else " "
+    stringBuilder.append("${prefix}$constructor(\n")
+
+    this.forEach { entry ->
+        entry.deepPrintMapEntryReflection(
+            stringBuilder = stringBuilder,
+            startingIndent = startingIndent,
+            indentSize = indentSize,
+        )
+    }
+    stringBuilder.append("${start})")
+    return stringBuilder.toString()
+}
+
+private fun <Any> Any?.deepPrintListItem(
+    stringBuilder: StringBuilder,
+    startingIndent: Int,
+    indentSize: Int
+) {
+    val totalIndent = startingIndent.indent() + indentSize.indent()
+
+    if (this == null) {
+        stringBuilder.append("${totalIndent}null,\n")
+    } else if (this!!::class.isPrimitive()) {
+        stringBuilder.append("${totalIndent}${deepPrintPrimitive(this)},\n")
+    } else {
+        stringBuilder.append(
+            this.deepPrintReflection(
+                initialIndentLength = startingIndent + indentSize,
+                indentIncrementLength = indentSize,
+            ) + "\n"
+        )
+    }
+}
+
+private fun <Any> Any?.deepPrintMapKeyOrValue(
+    stringBuilder: StringBuilder,
+    startingIndent: Int,
+    indentSize: Int
+) {
+    val totalIndent = startingIndent.indent() + indentSize.indent()
+
+    if (this == null) {
+        stringBuilder.append("${totalIndent}null")
+    } else if (this!!::class.isPrimitive()) {
+        stringBuilder.append("${totalIndent}${deepPrintPrimitive(this)}")
+    } else {
+        stringBuilder.append(
+            this.deepPrintReflection(
+                initialIndentLength = startingIndent + indentSize,
+                indentIncrementLength = indentSize,
+            )
+        )
+    }
+}
+
+private fun <K, V> Map.Entry<K, V?>.deepPrintMapEntryReflection(
+    stringBuilder: StringBuilder,
+    startingIndent: Int,
+    indentSize: Int,
+) {
+    key.deepPrintMapKeyOrValue(
+        stringBuilder = stringBuilder, 
+        startingIndent = startingIndent, 
+        indentSize = indentSize
+    )
+    val singleLine = key!!.isPrimitive() && ((value == null) || value!!.isPrimitive())
+    val toStr = if (singleLine) " to " else " to\n"
+    stringBuilder.append(toStr)
+    val newStartingIndent = if (singleLine) 0 else startingIndent + indentSize
+    val newIndentSize = if (singleLine) 0 else indentSize
+    value.deepPrintMapKeyOrValue(
+        stringBuilder = stringBuilder,
+        startingIndent = newStartingIndent,
+        indentSize = newIndentSize
+    )
+    val suffix = if (singleLine) ",\n" else "\n"
+    stringBuilder.append(suffix)
 }

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
@@ -48,7 +48,20 @@ fun Any?.deepPrintReflection(
                     )
                 },\n"
             )
-        } else {
+        } else if (propValue is Map<*,*>) {
+            builder.append(
+                "$initialIndent$indentIncrement$propName = ${
+                    propValue.deepPrintMapReflection(
+                        startingIndent = initialIndentLength + indentIncrementLength,
+                        indentSize = indentIncrementLength,
+                        standalone = false,
+                        constructor = "mutableMapOf",
+                    )
+                },\n"
+            )
+        }
+        
+        else {
             builder.append(
                 propValue.deepPrintReflection(
                     initialIndentLength = initialIndentLength + indentIncrementLength,
@@ -72,7 +85,7 @@ private fun Any.getPropertyValue(kParam: KParameter): Any? {
         .first { prop -> prop.name == kParam.name }.get(this)
 }
 
-fun <T : Any> KClass<T>.isPrimitive(): Boolean {
+internal fun <T : Any> KClass<T>.isPrimitive(): Boolean {
     return when (this) {
         Byte::class,
         Char::class,
@@ -100,137 +113,4 @@ fun Any.isPrimitive(): Boolean {
         is Double -> true
         else -> false
     }
-}
-
-fun <T> MutableList<T>.deepPrintMutableListReflection(
-    startingIndent: Int = 0,
-    indentSize: Int = 4,
-    standalone: Boolean = true,
-): String {
-    return this.deepPrintListReflection(
-        startingIndent = startingIndent,
-        indentSize = indentSize,
-        constructor = "mutableListOf",
-        standalone = standalone,
-    )
-}
-
-fun <T> List<T>.deepPrintListReflection(
-    startingIndent: Int = 0,
-    indentSize: Int = 4,
-    constructor: String = "listOf",
-    standalone: Boolean = true,
-): String {
-    val stringBuilder = StringBuilder()
-    val start = startingIndent.indent()
-    val prefix = if (standalone) start else " "
-    stringBuilder.append("${prefix}$constructor(\n")
-    this.forEach { value ->
-        value.deepPrintListItem(stringBuilder, startingIndent, indentSize)
-    }
-    stringBuilder.append("${start})")
-    return stringBuilder.toString()
-}
-
-fun <K, V> MutableMap<K, V>.deepPrintMutableMapReflection(
-    startingIndent: Int = 0,
-    indentSize: Int = 4,
-    constructor: String = "mutableMapOf",
-    standalone: Boolean = true,
-): String {
-    return deepPrintMapReflection(
-        startingIndent, 
-        indentSize, 
-        constructor, 
-        standalone,
-    )
-}
-
-
-fun <K, V> Map<K, V>.deepPrintMapReflection(
-    startingIndent: Int = 0,
-    indentSize: Int = 4,
-    constructor: String = "mapOf",
-    standalone: Boolean = true,
-): String {
-    val stringBuilder = StringBuilder()
-    val start = startingIndent.indent()
-    val prefix = if (standalone) start else " "
-    stringBuilder.append("${prefix}$constructor(\n")
-
-    this.forEach { entry ->
-        entry.deepPrintMapEntryReflection(
-            stringBuilder = stringBuilder,
-            startingIndent = startingIndent,
-            indentSize = indentSize,
-        )
-    }
-    stringBuilder.append("${start})")
-    return stringBuilder.toString()
-}
-
-private fun <Any> Any?.deepPrintListItem(
-    stringBuilder: StringBuilder,
-    startingIndent: Int,
-    indentSize: Int
-) {
-    val totalIndent = startingIndent.indent() + indentSize.indent()
-
-    if (this == null) {
-        stringBuilder.append("${totalIndent}null,\n")
-    } else if (this!!::class.isPrimitive()) {
-        stringBuilder.append("${totalIndent}${deepPrintPrimitive(this)},\n")
-    } else {
-        stringBuilder.append(
-            this.deepPrintReflection(
-                initialIndentLength = startingIndent + indentSize,
-                indentIncrementLength = indentSize,
-            ) + "\n"
-        )
-    }
-}
-
-private fun <Any> Any?.deepPrintMapKeyOrValue(
-    stringBuilder: StringBuilder,
-    startingIndent: Int,
-    indentSize: Int
-) {
-    val totalIndent = startingIndent.indent() + indentSize.indent()
-
-    if (this == null) {
-        stringBuilder.append("${totalIndent}null")
-    } else if (this!!::class.isPrimitive()) {
-        stringBuilder.append("${totalIndent}${deepPrintPrimitive(this)}")
-    } else {
-        stringBuilder.append(
-            this.deepPrintReflection(
-                initialIndentLength = startingIndent + indentSize,
-                indentIncrementLength = indentSize,
-            )
-        )
-    }
-}
-
-private fun <K, V> Map.Entry<K, V?>.deepPrintMapEntryReflection(
-    stringBuilder: StringBuilder,
-    startingIndent: Int,
-    indentSize: Int,
-) {
-    key.deepPrintMapKeyOrValue(
-        stringBuilder = stringBuilder, 
-        startingIndent = startingIndent, 
-        indentSize = indentSize
-    )
-    val singleLine = key!!.isPrimitive() && ((value == null) || value!!.isPrimitive())
-    val toStr = if (singleLine) " to " else " to\n"
-    stringBuilder.append(toStr)
-    val newStartingIndent = if (singleLine) 0 else startingIndent + indentSize
-    val newIndentSize = if (singleLine) 0 else indentSize
-    value.deepPrintMapKeyOrValue(
-        stringBuilder = stringBuilder,
-        startingIndent = newStartingIndent,
-        indentSize = newIndentSize
-    )
-    val suffix = if (singleLine) ",\n" else "\n"
-    stringBuilder.append(suffix)
 }

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
@@ -5,58 +5,26 @@ import org.junit.jupiter.api.Test
 
 class ReflectionTest {
     
-    data class Address(
-        val streetAddress: String,
-        val city: String,
-        val state: String,
-        val zipCode: String
-    )
-    
-    data class Person(
-        val name: String,
-        val age: Int,
-        val address: Address,
-    )
-    
-    data class PrimitivesContainer(
-        val boolean: Boolean = true,
-        val short: Short = 5,
-        val byte: Byte = 127,
-        val char: Char = 'a',
-        val int: Int = 42,
-        val float: Float = 26.2f,
-        val double: Double = 26.2,
-        val string: String = "Hello World"
-    )
-    
-    data class MutableListContainer(
-        val someString: String,
-        val numbers: MutableList<Int>
-    )
-
-    data class ListContainer(
-        val someString: String,
-        val numbers: List<Int>
-    )
-    
-    data class WithMutableListOfDataClasses(
-        val id: String,
-        val people: MutableList<Person>,
-        val mutableListContainer: MutableListContainer
-    )
-
-    data class WithListOfDataClasses(
-        val id: String,
-        val people: List<Person>,
-        val listContainer: ListContainer
-    )
-    
     @Test
-    fun primitives() {
+    fun `deep print data class with all primitives and only primitives`() {
         val primitivesContainer = PrimitivesContainer()
+        val expected = """
+            PrimitivesContainer(
+                boolean = true,
+                short = 5,
+                byte = 127,
+                char = 'a',
+                int = 42,
+                float = 26.2f,
+                double = 26.2,
+                string = "Hello World",
+            )
+        """.trimIndent()
         val actual = primitivesContainer.deepPrintReflection()
-        println(actual)
+        
+        assertEquals(expected, actual)
     }
+    
     @Test
     fun `data class in a data class`() {
         val brady = Person(
@@ -88,7 +56,7 @@ class ReflectionTest {
     }
     
     @Test
-    fun `deep print list Integers`() {
+    fun `deep print list of Integers`() {
         val myList = listOf(1, 2, 3, 4, 5)
         val expected = """
             listOf(
@@ -104,7 +72,23 @@ class ReflectionTest {
     }
 
     @Test
-    fun `deep print data class with list Integers`() {
+    fun `deep print mutable list of Integers`() {
+        val myList = mutableListOf(1, 2, 3, 4, 5)
+        val expected = """
+            mutableListOf(
+                1,
+                2,
+                3,
+                4,
+                5,
+            )
+        """.trimIndent()
+        val actual = myList.deepPrintMutableListReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print data class with a list of Integers`() {
         
         val myMutableList = mutableListOf(1, 2, 3, 4, 5)
         val someMutableListContainer = createMutableListContainer(myMutableList)
@@ -365,18 +349,7 @@ class ReflectionTest {
 
     @Test
     fun `deep print Map standalone data class values`() {
-        val dishes = listOf(
-            Dish(
-                name = "Pizza",
-                ingredients = listOf("dough", "tomato sauce", "cheese")
-            ),
-            Dish(
-                name = "Mac n Cheese",
-                ingredients = listOf("mac", "cheese")
-            )
-        )
-        val days = listOf("Monday", "Tuesday")
-        val dayDishMap = days.zip(dishes).toMap().toMutableMap()
+        val dayDishMap = createMap()
         val expected = """
             mapOf(
                 "Monday" to
@@ -402,10 +375,69 @@ class ReflectionTest {
         assertEquals(expected, actual)
     }
 
+    private fun createMap(): MutableMap<String, Dish> {
+        val dishes = listOf(
+            Dish(
+                name = "Pizza",
+                ingredients = listOf("dough", "tomato sauce", "cheese")
+            ),
+            Dish(
+                name = "Mac n Cheese",
+                ingredients = listOf("mac", "cheese")
+            )
+        )
+        val days = listOf("Monday", "Tuesday")
+        val dayDishMap = days.zip(dishes).toMap().toMutableMap()
+        return dayDishMap
+    }
+
     data class Dish(
         val name: String,
         val ingredients: List<String>,
     )
+    
+    data class MapContainer(
+        val name: String,
+        val mapToHold: Map<String, Dish>,
+        val id: Int,
+    )
+    
+    @Test
+    fun `deep print data class with Map`() {
+        val dayDishMap = createMap()
+        val mapContainer = MapContainer(
+            name = "my map",
+            mapToHold = dayDishMap,
+            id = 12345,
+        )
+        val expected = """
+            MapContainer(
+                name = "my map",
+                mapToHold =  mutableMapOf(
+                    "Monday" to
+                        Dish(
+                            name = "Pizza",
+                            ingredients =  mutableListOf(
+                                "dough",
+                                "tomato sauce",
+                                "cheese",
+                            ),
+                        ),
+                    "Tuesday" to
+                        Dish(
+                            name = "Mac n Cheese",
+                            ingredients =  mutableListOf(
+                                "mac",
+                                "cheese",
+                            ),
+                        ),
+                ),
+                id = 12345,
+            )
+        """.trimIndent()
+        val actual = mapContainer.deepPrintReflection()
+        assertEquals(expected, actual)
+    }
     
     private fun createMutableListOfPeople(): MutableList<Person> {
         val brady = Person(
@@ -448,4 +480,3 @@ class ReflectionTest {
         )
     }
 }
-

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
@@ -99,7 +99,7 @@ class ReflectionTest {
                 5,
             )
         """.trimIndent()
-        val actual = myList.deepPrintListReflect()
+        val actual = myList.deepPrintListReflection()
         assertEquals(expected, actual)
     }
 
@@ -137,7 +137,7 @@ class ReflectionTest {
                 5.0f,
             )
         """.trimIndent()
-        val actual = myList.deepPrintListReflect()
+        val actual = myList.deepPrintListReflection()
         assertEquals(expected, actual)
     }
 
@@ -153,7 +153,7 @@ class ReflectionTest {
                 5.0,
             )
         """.trimIndent()
-        val actual = myList.deepPrintListReflect()
+        val actual = myList.deepPrintListReflection()
         assertEquals(expected, actual)
     }
 
@@ -169,7 +169,7 @@ class ReflectionTest {
                 "Hello",
             )
         """.trimIndent()
-        val actual = myList.deepPrintListReflect()
+        val actual = myList.deepPrintListReflection()
         assertEquals(expected, actual)
     }
 
@@ -185,7 +185,7 @@ class ReflectionTest {
                 "Hello",
             )
         """.trimIndent()
-        val actual = myList.deepPrintListReflect()
+        val actual = myList.deepPrintListReflection()
         assertEquals(expected, actual)
     }
     
@@ -209,10 +209,10 @@ class ReflectionTest {
                         name = "Brady",
                         age = 38,
                         Address(
-                            streetAddress = "19 Jolley Way",
-                            city = "Scotts Valley",
+                            streetAddress = "414 Koshland Way",
+                            city = "Santa Cruz",
                             state = "CA",
-                            zipCode = "95066",
+                            zipCode = "95064",
                         ),
                     ),
                     Person(
@@ -260,10 +260,10 @@ class ReflectionTest {
                         name = "Brady",
                         age = 38,
                         Address(
-                            streetAddress = "19 Jolley Way",
-                            city = "Scotts Valley",
+                            streetAddress = "414 Koshland Way",
+                            city = "Santa Cruz",
                             state = "CA",
-                            zipCode = "95066",
+                            zipCode = "95064",
                         ),
                     ),
                     Person(
@@ -292,16 +292,130 @@ class ReflectionTest {
         val actual = listOfDataClasses.deepPrintReflection()
         assertEquals(expected, actual)
     }
+    
+    @Test
+    fun `deep print Map standalone primitives`() {
+        val map = mapOf(
+            1 to "a", 
+            2 to "b", 
+            3 to "c"
+        )
+        val expected = """
+            mapOf(
+                1 to "a",
+                2 to "b",
+                3 to "c",
+            )
+        """.trimIndent()
+        val actual = map.deepPrintMapReflection()
+        assertEquals(expected, actual)
+    }
 
+    @Test
+    fun `deep print MutableMap standalone primitives`() {
+        val mutableMap: MutableMap<Int, String?> = mutableMapOf(
+            1 to "a",
+            2 to "b",
+            3 to "c"
+        )
+        val expected = """
+            mutableMapOf(
+                1 to "a",
+                2 to "b",
+                3 to "c",
+            )
+        """.trimIndent()
+        val actual = mutableMap.deepPrintMutableMapReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print MutableMap standalone data class values`() {
+        val map = listOf(1, 2).zip(createMutableListOfPeople()).toMap().toMutableMap()
+        val expected = """
+            mutableMapOf(
+                1 to
+                    Person(
+                        name = "Brady",
+                        age = 38,
+                        Address(
+                            streetAddress = "414 Koshland Way",
+                            city = "Santa Cruz",
+                            state = "CA",
+                            zipCode = "95064",
+                        ),
+                    ),
+                2 to
+                    Person(
+                        name = "Joe",
+                        age = 80,
+                        Address(
+                            streetAddress = "1600 Pennsylvania Avenue, N.W.",
+                            city = "Washington",
+                            state = "DC",
+                            zipCode = "20500",
+                        ),
+                    ),
+            )
+        """.trimIndent()
+        
+        val actual = map.deepPrintMutableMapReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print Map standalone data class values`() {
+        val dishes = listOf(
+            Dish(
+                name = "Pizza",
+                ingredients = listOf("dough", "tomato sauce", "cheese")
+            ),
+            Dish(
+                name = "Mac n Cheese",
+                ingredients = listOf("mac", "cheese")
+            )
+        )
+        val days = listOf("Monday", "Tuesday")
+        val dayDishMap = days.zip(dishes).toMap().toMutableMap()
+        val expected = """
+            mapOf(
+                "Monday" to
+                    Dish(
+                        name = "Pizza",
+                        ingredients =  mutableListOf(
+                            "dough",
+                            "tomato sauce",
+                            "cheese",
+                        ),
+                    ),
+                "Tuesday" to
+                    Dish(
+                        name = "Mac n Cheese",
+                        ingredients =  mutableListOf(
+                            "mac",
+                            "cheese",
+                        ),
+                    ),
+            )
+        """.trimIndent()
+        val actual = dayDishMap.deepPrintMapReflection()
+        assertEquals(expected, actual)
+    }
+
+    data class Dish(
+        val name: String,
+        val ingredients: List<String>,
+    )
+    
     private fun createMutableListOfPeople(): MutableList<Person> {
         val brady = Person(
             name = "Brady",
             age = 38,
             Address(
-                streetAddress = "19 Jolley Way",
-                city = "Scotts Valley",
+                streetAddress = "414 Koshland Way",
+                city = "Santa Cruz",
                 state = "CA",
-                zipCode = "95066"
+                zipCode = "95064"
             )
         )
         val prez = Person(

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
@@ -1,0 +1,47 @@
+package com.bradyaiello.deepprint
+
+data class Address(
+    val streetAddress: String,
+    val city: String,
+    val state: String,
+    val zipCode: String
+)
+
+data class Person(
+    val name: String,
+    val age: Int,
+    val address: Address,
+)
+
+data class PrimitivesContainer(
+    val boolean: Boolean = true,
+    val short: Short = 5,
+    val byte: Byte = 127,
+    val char: Char = 'a',
+    val int: Int = 42,
+    val float: Float = 26.2f,
+    val double: Double = 26.2,
+    val string: String = "Hello World"
+)
+
+data class MutableListContainer(
+    val someString: String,
+    val numbers: MutableList<Int>
+)
+
+data class ListContainer(
+    val someString: String,
+    val numbers: List<Int>
+)
+
+data class WithMutableListOfDataClasses(
+    val id: String,
+    val people: MutableList<Person>,
+    val mutableListContainer: MutableListContainer
+)
+
+data class WithListOfDataClasses(
+    val id: String,
+    val people: List<Person>,
+    val listContainer: ListContainer
+)


### PR DESCRIPTION
Issue #20 

[Issue]
The reflection implementation supports `List` and `MutableList`. We need to do the same for `Map` and `MutableMap`.

[Fix]
Add public extension functions to `Map` and `MutableMap`, and let `deepPrintReflection()` delegate to them.
As with the `List` and `MutableList` implementations, at runtime, there is no difference between a `Map` and a `MutableMap`; we can only get that distinction at compile time, as in the KSP implementation. When the `Map` or `MutableMap` is a standalone object, we can call the appropriate extension function, `deepPrintMapReflection()` or `deepPrintMutableMapReflection(). When it is a property of a `data class`, we use the `mutableMapOf()` constructor to fit both cases.

[Test]
- Unit tests for standalone maps with primitives and objects
- Unit tests for maps as properties of data classes