### PR TITLE
[Issue-22] Reflection: Support Arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DeepPrint
-## A utility for printing kotlin data classes with the same syntax as their primary constructor, using [ksp](https://github.com/google/ksp.) 
+## A utility for printing kotlin data classes with the same syntax as their primary constructor.
 
 ## Benefits:
 
@@ -10,7 +10,7 @@ Don't print with the default `toString()` like this in your logs:
 ```
 ThreeClassesDeep3(age=55, person=SamplePersonClass(name=Dave, sampleClass=SampleClass(x=0.5, y=2.6, name=A point)), sampleClass=SampleClass(x=0.5, y=2.6, name=A point))
 ```
-Use `deepPrint()` to print this instead:
+Use `deepPrint()` or `deepPrintReflection()` to print this instead:
 ```kotlin
 ThreeClassesDeep3(
   age = 55,
@@ -32,7 +32,103 @@ ThreeClassesDeep3(
     ),
 )
 ```
-## Simple Example
+
+## KSP vs. Reflection
+DeepPrint offers 2 implementations: 1 using KSP and the other using reflection.
+They have similar functionality, but don't have exact parity. This is partly 
+due to the limitations of reflection, and partly because some features have
+not been added yet.
+
+### KSP
+[Kotlin Symbol Processing](https://github.com/google/ksp) is a configurable
+code generation Kotlin compiler plugin from Google. Its benefits are:
+
+- Kotlin Multiplatform support
+- More precise type information at compile time
+- Likely faster at runtime
+
+To see it in action, check out [KSP Simple Example](#KSP-Simple-Example) and
+[KSP Deeper Example](#KSP-Deeper-Example).
+To try it out, please refer to [KSP Quick Start](#KSP-Quick-Start).
+
+### Reflection
+The reflection implementation is only for Kotlin on the JVM, but its benefits are:
+
+- Only 1 dependency to add
+- No plugin to apply
+- No need to recompile / regenerate any code on changes to your `data class`es
+
+## Reflection Quick Start
+
+If you're using Kotlin on the JVM or Android, just add the dependency:
+
+```kotlin
+implementation("com.bradyaiello.deepprint:deep-print-reflection:<latest-version>")
+```
+
+Now, calling `deepPrintReflection()` on a `data class` will return a readable `String`
+that is a valid Kotlin constructor call:
+
+```kotlin
+MapContainer(
+    name = "my map",
+    mapToHold =  mutableMapOf(
+        "Monday" to
+            Dish(
+                name = "Pizza",
+                ingredients =  mutableListOf(
+                    "dough",
+                    "tomato sauce",
+                    "cheese",
+                ),
+            ),
+        "Tuesday" to
+            Dish(
+                name = "Mac n Cheese",
+                ingredients =  mutableListOf(
+                    "mac",
+                    "cheese",
+                ),
+            ),
+    ),
+    id = 12345,
+)
+```
+
+### Reflection and Collection Types
+
+There are also versions of `deepPrintReflection()` just for collection types.
+
+```kotlin
+listOf("Hi", "Hey", "How's it going?", "What's up?", "Hello")
+    .deepPrintListReflection()
+```
+
+The above prints:
+
+```kotlin
+listOf(
+    "Hi",
+    "Hey",
+    "How's it going?",
+    "What's up?",
+    "Hello",
+)
+```
+
+Why the different function names for collections?
+
+You may notice in the `MapContainer` that it prints `mutableMapOf()`
+and not `mapOf()`.
+At runtime, we can't know if we're dealing with a `Map` or a `MutableMap`.
+`MutableMap` fits the bill for both, so in a `data class`, `mutableMapOf()`,
+`mutableListOf()`, etc. are used.
+However, If you're only printing the collection as a standalone object, then
+you know the type, and may want to reflect that.
+For this reason, there are functions for both mutable and immutable variants,
+eg. `deepPrintListReflection()` and `deepPrintMutableListReflection()`.
+
+## KSP Simple Example
 For a simple example, we'll use a small class `SampleClass`:
 ```kotlin
 data class SampleClass(val x: Float, val y: Float, val name: String)
@@ -50,7 +146,7 @@ SampleClass(
 )
 ```
 This can save a lot of time turning real data into test data on deeper objects.
-## Deeper Sample
+## KSP Deeper Sample
 Given the classes:
 ```kotlin
 data class SampleClass(val x: Float, val y: Float, val name: String)
@@ -88,6 +184,9 @@ You can see more examples in [test-project](./test-project/src/test/kotlin/com/b
 ## Usage
 Given the previous sample classes, we just add the `@DeepPrint` annotation,
 and DeepPrint generates the `deepPrint()` extension functions.
+Like `@Parcelable`, all `data class` properties of a `data class` must also
+be annotated.
+
 ```kotlin
 @DeepPrint
 data class SampleClass(val x: Float, val y: Float, val name: String)
@@ -98,7 +197,7 @@ data class SamplePersonClass(val name: String, val sampleClass: SampleClass)
 @DeepPrint
 data class ThreeClassesDeep(val person: SamplePersonClass, val age: Int)
 ```
-## Quick Start
+## KSP Quick Start
 
 ### Add KSP
 You can reference the [KSP quickstart docs](https://kotlinlang.org/docs/ksp-quickstart.html#use-your-own-processor-in-a-project) for this, or check out the sample projects:
@@ -127,7 +226,7 @@ plugins {
     id("com.google.devtools.ksp")
 }
 ```
-2. Add the dependencies
+1. Add the dependencies
 ```kotlin
 dependencies {
     // @DeepPrint annotation and a few helper functions
@@ -138,7 +237,7 @@ dependencies {
     ksp(implementation("com.bradyaiello.deepprint:deep-print-processor:0.1.0-alpha"))
 }
 ```
-3. Tell Gradle where to find the KSP-generated code.
+1. Tell Gradle where to find the KSP-generated code.
 ```kotlin
 kotlin.sourceSets {
     main {
@@ -153,7 +252,7 @@ kotlin.sourceSets {
     }
 }
 ```
-4. Optionally, configure the number of spaces for indentation; it defaults to 4.
+1. Optionally, configure the number of spaces for indentation; it defaults to 4.
 ```kotlin
 ksp {
     arg("indent", "2")
@@ -168,7 +267,7 @@ plugins {
     id("com.google.devtools.ksp")
 }
 ```
-2. Add the annotations dependency, and tell Gradle where it can find the generated code. 
+1. Add the annotations dependency, and tell Gradle where it can find the generated code. 
 ```kotlin
 kotlin {
     sourceSets {
@@ -181,7 +280,7 @@ kotlin {
     }
 }
 ```
-3. Run KSP on the `commonMain` source set before any other compile tasks.
+1. Run KSP on the `commonMain` source set before any other compile tasks.
 ```kotlin
 // https://github.com/evant/kotlin-inject/issues/193#issuecomment-1112930931
 tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
@@ -191,13 +290,13 @@ tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
     kotlinOptions.freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
 }
 ```
-4. Tell KSP what processor(s) to use, and for what configurations. Here we're assuming we just run it against the `commonMain` source set.
+1. Tell KSP what processor(s) to use, and for what configurations. Here we're assuming we just run it against the `commonMain` source set.
 ```kotlin
 dependencies {
     add("kspCommonMainMetadata", project(":deep-print-processor"))
 }
 ```
-5. Optionally, configure the number of spaces for indentation; it defaults to 4.
+1. Optionally, configure the number of spaces for indentation; it defaults to 4.
 
 ```kotlin
 ksp {
@@ -212,12 +311,14 @@ That is not true for single source projects, like [test-project](./test-project)
 
 ## Current Limitations
 - DeepPrint only works on `data class`es.
-- KSP [does not support](https://github.com/google/ksp/issues/1056) using the IR Kotlin JS compiler, so we're using Legacy.
-- For the entire printed object to be a valid constructor call, all classes in the hierarchy must be annotated.
-- If an annotated data class has a property of a non-annotated class, the property's value is printed with a standard `toString()`.
-- DeepPrint supports `List`, `MutableList`, and `Array` but does not support all collections yet.
-- In KMP projects, KSP [does not yet support](https://github.com/google/ksp/issues/567) generating code from the `commonTest` source set. 
-Hence, test classes for the KMP test project are in `commonMain`.
+- KSP [does not support](https://github.com/google/ksp/issues/1056) using the IR Kotlin JS compiler, so we're using 
+  Legacy.
+- For KSP, for the entire printed object to be a valid constructor call, all classes in the hierarchy must be annotated.
+- For KSP, if an annotated data class has a property of a non-annotated class, the property's value is printed with a 
+  standard `toString()`.
+- Not all collection types are supported yet.
+- In KMP projects, KSP [does not yet support](https://github.com/google/ksp/issues/567) generating code from the 
+  `commonTest` source set. Hence, test classes for the KMP test project are in `commonMain`.
 
 ## Thanks
 Thank you Pavlo Stavytskyi for the sample KSP project and its accompanying article.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ SampleClass(
 )
 ```
 This can save a lot of time turning real data into test data on deeper objects.
-## KSP Deeper Sample
+## KSP Deeper Example
 Given the classes:
 ```kotlin
 data class SampleClass(val x: Float, val y: Float, val name: String)

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ plugins {
     id("com.google.devtools.ksp")
 }
 ```
-1. Add the dependencies
+2. Add the dependencies
 ```kotlin
 dependencies {
     // @DeepPrint annotation and a few helper functions
@@ -237,7 +237,7 @@ dependencies {
     ksp(implementation("com.bradyaiello.deepprint:deep-print-processor:0.1.0-alpha"))
 }
 ```
-1. Tell Gradle where to find the KSP-generated code.
+3. Tell Gradle where to find the KSP-generated code.
 ```kotlin
 kotlin.sourceSets {
     main {
@@ -252,7 +252,7 @@ kotlin.sourceSets {
     }
 }
 ```
-1. Optionally, configure the number of spaces for indentation; it defaults to 4.
+4. Optionally, configure the number of spaces for indentation; it defaults to 4.
 ```kotlin
 ksp {
     arg("indent", "2")
@@ -267,7 +267,7 @@ plugins {
     id("com.google.devtools.ksp")
 }
 ```
-1. Add the annotations dependency, and tell Gradle where it can find the generated code. 
+2. Add the annotations dependency, and tell Gradle where it can find the generated code. 
 ```kotlin
 kotlin {
     sourceSets {
@@ -280,7 +280,7 @@ kotlin {
     }
 }
 ```
-1. Run KSP on the `commonMain` source set before any other compile tasks.
+3. Run KSP on the `commonMain` source set before any other compile tasks.
 ```kotlin
 // https://github.com/evant/kotlin-inject/issues/193#issuecomment-1112930931
 tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
@@ -290,13 +290,13 @@ tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
     kotlinOptions.freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
 }
 ```
-1. Tell KSP what processor(s) to use, and for what configurations. Here we're assuming we just run it against the `commonMain` source set.
+4. Tell KSP what processor(s) to use, and for what configurations. Here we're assuming we just run it against the `commonMain` source set.
 ```kotlin
 dependencies {
     add("kspCommonMainMetadata", project(":deep-print-processor"))
 }
 ```
-1. Optionally, configure the number of spaces for indentation; it defaults to 4.
+5. Optionally, configure the number of spaces for indentation; it defaults to 4.
 
 ```kotlin
 ksp {

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectArray.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectArray.kt
@@ -1,0 +1,34 @@
+package com.bradyaiello.deepprint
+
+fun <T> Array<T>.deepPrintArrayReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "arrayOf",
+        standalone = true,
+    )
+): String {
+    return with(deepPrintReflectConfig) {
+        deepPrintArrayReflection(
+            startingIndent = startingIndent,
+            indentSize = indentSize,
+            constructor = constructor,
+            standalone = standalone,
+        )
+    }
+}
+
+fun <T> Array<T>.deepPrintArrayReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "arrayOf",
+    standalone: Boolean = true,
+): String {
+    val stringBuilder = StringBuilder()
+    val start = startingIndent.indent()
+    val prefix = if (standalone) start else " "
+    stringBuilder.append("${prefix}$constructor(\n")
+    this.forEach { value ->
+        value.deepPrintListItem(stringBuilder, startingIndent, indentSize)
+    }
+    stringBuilder.append("${start})")
+    return stringBuilder.toString()
+}

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectList.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectList.kt
@@ -1,6 +1,22 @@
 package com.bradyaiello.deepprint
 
 fun <T> List<T>.deepPrintListReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "listOf",
+        standalone = true,
+    )
+): String {
+    return with(deepPrintReflectConfig){
+        deepPrintListReflection(
+            startingIndent = startingIndent,
+            indentSize = indentSize,
+            constructor = constructor,
+            standalone = standalone,
+        )
+    }
+}
+
+fun <T> List<T>.deepPrintListReflection(
     startingIndent: Int = 0,
     indentSize: Int = 4,
     constructor: String = "listOf",
@@ -18,14 +34,31 @@ fun <T> List<T>.deepPrintListReflection(
 }
 
 fun <T> MutableList<T>.deepPrintMutableListReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "mutableListOf",
+        standalone = true,
+    )
+): String {
+    return with(deepPrintReflectConfig) {
+        deepPrintMutableListReflection(
+            startingIndent = startingIndent,
+            indentSize = indentSize,
+            constructor = constructor,
+            standalone = standalone,
+        )
+    }
+}
+
+fun <T> MutableList<T>.deepPrintMutableListReflection(
     startingIndent: Int = 0,
     indentSize: Int = 4,
+    constructor: String = "mutableListOf",
     standalone: Boolean = true,
 ): String {
     return this.deepPrintListReflection(
         startingIndent = startingIndent,
         indentSize = indentSize,
-        constructor = "mutableListOf",
+        constructor = constructor,
         standalone = standalone,
     )
 }
@@ -50,3 +83,4 @@ internal fun <Any> Any?.deepPrintListItem(
         )
     }
 }
+

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectMap.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectMap.kt
@@ -1,5 +1,22 @@
 package com.bradyaiello.deepprint
 
+
+fun <K, V> MutableMap<K, V>.deepPrintMutableMapReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "mutableMapOf",
+        standalone = true,
+    )
+): String {
+    return with(deepPrintReflectConfig) {
+        deepPrintMutableMapReflection(
+            startingIndent = startingIndent,
+            indentSize = indentSize,
+            constructor = constructor,
+            standalone = standalone,
+        )
+    }
+}
+
 fun <K, V> MutableMap<K, V>.deepPrintMutableMapReflection(
     startingIndent: Int = 0,
     indentSize: Int = 4,
@@ -14,6 +31,21 @@ fun <K, V> MutableMap<K, V>.deepPrintMutableMapReflection(
     )
 }
 
+fun <K, V> Map<K, V>.deepPrintMapReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "mapOf",
+        standalone = true,
+    )
+): String {
+    return with(deepPrintReflectConfig) {
+        deepPrintMapReflection(
+            startingIndent = startingIndent,
+            indentSize = indentSize,
+            constructor = constructor,
+            standalone = standalone,
+        )
+    }
+}
 
 fun <K, V> Map<K, V>.deepPrintMapReflection(
     startingIndent: Int = 0,

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
@@ -497,8 +497,7 @@ class ReflectionTest {
             )
         )
         val days = listOf("Monday", "Tuesday")
-        val dayDishMap = days.zip(dishes).toMap().toMutableMap()
-        return dayDishMap
+        return days.zip(dishes).toMap().toMutableMap()
     }
 
     data class Dish(

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
@@ -88,6 +88,69 @@ class ReflectionTest {
     }
 
     @Test
+    fun `deep print array of Integers`() {
+        val myList = arrayOf(1, 2, 3, 4, 5)
+        val expected = """
+            arrayOf(
+                1,
+                2,
+                3,
+                4,
+                5,
+            )
+        """.trimIndent()
+        val actual = myList.deepPrintArrayReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print data class with arrays`() {
+        val myArray = arrayOf(1, 2, 3, 4, 5)
+        val arrayHolder = ArrayHolder(
+            someString = "Here's a string",
+            numbers = myArray,
+            primitiveContainers = arrayOf(PrimitivesContainer(), PrimitivesContainer())
+        )
+        val expected = """
+            ArrayHolder(
+                someString = "Here's a string",
+                numbers =  arrayOf(
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                ),
+                primitiveContainers =  arrayOf(
+                    PrimitivesContainer(
+                        boolean = true,
+                        short = 5,
+                        byte = 127,
+                        char = 'a',
+                        int = 42,
+                        float = 26.2f,
+                        double = 26.2,
+                        string = "Hello World",
+                    ),
+                    PrimitivesContainer(
+                        boolean = true,
+                        short = 5,
+                        byte = 127,
+                        char = 'a',
+                        int = 42,
+                        float = 26.2f,
+                        double = 26.2,
+                        string = "Hello World",
+                    ),
+                ),
+            )
+        """.trimIndent()
+        val actual = arrayHolder.deepPrintReflection()
+        println(actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `deep print data class with a list of Integers`() {
         
         val myMutableList = mutableListOf(1, 2, 3, 4, 5)
@@ -170,6 +233,53 @@ class ReflectionTest {
             )
         """.trimIndent()
         val actual = myList.deepPrintListReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print standalone Array primitives`() {
+        val myArray = arrayOf(1, 2, 3, 4, 5)
+        val expected = """
+            arrayOf(
+                1,
+                2,
+                3,
+                4,
+                5,
+            )
+        """.trimIndent()
+        val actual = myArray.deepPrintArrayReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print standalone Array data classes`() {
+        val myArray = createMutableListOfPeople().toTypedArray()
+        val expected = """
+                arrayOf(
+                    Person(
+                        name = "Brady",
+                        age = 38,
+                        Address(
+                            streetAddress = "414 Koshland Way",
+                            city = "Santa Cruz",
+                            state = "CA",
+                            zipCode = "95064",
+                        ),
+                    ),
+                    Person(
+                        name = "Joe",
+                        age = 80,
+                        Address(
+                            streetAddress = "1600 Pennsylvania Avenue, N.W.",
+                            city = "Washington",
+                            state = "DC",
+                            zipCode = "20500",
+                        ),
+                    ),
+                )
+        """.trimIndent()
+        val actual = myArray.deepPrintArrayReflection()
         assertEquals(expected, actual)
     }
     

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
@@ -45,3 +45,9 @@ data class WithListOfDataClasses(
     val people: List<Person>,
     val listContainer: ListContainer
 )
+
+data class ArrayHolder(
+    val someString: String,
+    val numbers: Array<Int>,
+    val primitiveContainers: Array<PrimitivesContainer>
+)


### PR DESCRIPTION
[Issue #22 ]
The reflection implementation needs to support Arrays by themselves, as well as members of data classes. They also need to be able to accomodate primitives and data classes as their type parameter.

[Fix]
Follow the logic of List, just with a different constructor. Add a DeepPrintReflectConfig data class to simplify config, and keep the main deepPrintReflection() function smaller.

[Test]
Added unit tests that cover all 4 listed scenarios