### PR TITLE
KSP: support Set, MutableSet and the primitive arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,54 @@ ThreeClassesDeep(
 ```
 We can just copy this from a log and use it in a test without modification.
 You can see more examples in [test-project](./test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt) and [test-project-multiplatform](./test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt)
+### KSP and Collection Types
+
+A property whose type is one of these is printed as the call that rebuilds it:
+
+| Property type | Printed as |
+| --- | --- |
+| `List<T>` | `listOf<T>(...)` |
+| `MutableList<T>` | `mutableListOf<T>(...)` |
+| `Set<T>` | `setOf<T>(...)` |
+| `MutableSet<T>` | `mutableSetOf<T>(...)` |
+| `Array<T>` | `arrayOf<T>(...)` |
+| `Map<K, V>` | `mapOf<K, V>(...)` |
+| `MutableMap<K, V>` | `mutableMapOf<K, V>(...)` |
+| `ByteArray`, `ShortArray`, `IntArray`, `LongArray` | `byteArrayOf(...)`, `shortArrayOf(...)`, `intArrayOf(...)`, `longArrayOf(...)` |
+| `FloatArray`, `DoubleArray`, `BooleanArray`, `CharArray` | `floatArrayOf(...)`, `doubleArrayOf(...)`, `booleanArrayOf(...)`, `charArrayOf(...)` |
+
+Unlike the reflection implementation, KSP sees the declared type, so a `Set` prints
+as `setOf()` and a `MutableSet` prints as `mutableSetOf()`.
+
+Elements may be primitives or `@DeepPrint`-annotated `data class`es. Given:
+
+```kotlin
+@DeepPrint
+data class Surfer(val name: String, val surfboard: Surfboard)
+
+@DeepPrint
+data class Lineup(val name: String, val surfers: Set<Surfer>)
+```
+
+`lineup.deepPrint()` prints:
+
+```kotlin
+Lineup(
+    name = "Pipeline",
+    surfers = setOf<Surfer>(
+        Surfer(
+            name = "Kelly Slater",
+            surfboard = 
+                Surfboard(
+                    length = 5.9f,
+                    width = 1.8f,
+                    style = "shortboard",
+                ),
+        ),
+    ),
+)
+```
+
 ## Usage
 Given the previous sample classes, we just add the `@DeepPrint` annotation,
 and DeepPrint generates the `deepPrint()` extension functions.
@@ -318,7 +366,13 @@ That is not true for single source projects, like [test-project](./test-project)
 - For KSP, for the entire printed object to be a valid constructor call, all classes in the hierarchy must be annotated.
 - For KSP, if an annotated data class has a property of a non-annotated class, the property's value is printed with a 
   standard `toString()`.
-- Not all collection types are supported yet.
+- Not all collection types are supported yet. See
+  [KSP and Collection Types](#KSP-and-Collection-Types) for what KSP handles, and
+  [Reflection and Collection Types](#Reflection-and-Collection-Types) for reflection.
+- On Kotlin/JS, `Float`, `Double` and `Char` elements of a `List`, `Set` or `Array` are
+  identified by their runtime type, which JS erases to a number. `2.0f` prints as `2` and
+  `'A'` prints as `65`. `FloatArray`, `DoubleArray` and `CharArray` are not affected, and
+  neither are properties declared directly on a `data class`.
 - In KMP projects, KSP [does not yet support](https://github.com/google/ksp/issues/567) generating code from the 
   `commonTest` source set. Hence, test classes for the KMP test project are in `commonMain`.
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ A property whose type is one of these is printed as the call that rebuilds it:
 | `Array<T>` | `arrayOf<T>(...)` |
 | `Map<K, V>` | `mapOf<K, V>(...)` |
 | `MutableMap<K, V>` | `mutableMapOf<K, V>(...)` |
+| `ArrayList<T>` | `arrayListOf<T>(...)` |
+| `HashSet<T>` | `hashSetOf<T>(...)` |
+| `LinkedHashSet<T>` | `linkedSetOf<T>(...)` |
+| `HashMap<K, V>` | `hashMapOf<K, V>(...)` |
+| `LinkedHashMap<K, V>` | `linkedMapOf<K, V>(...)` |
 | `ByteArray`, `ShortArray`, `IntArray`, `LongArray` | `byteArrayOf(...)`, `shortArrayOf(...)`, `intArrayOf(...)`, `longArrayOf(...)` |
 | `FloatArray`, `DoubleArray`, `BooleanArray`, `CharArray` | `floatArrayOf(...)`, `doubleArrayOf(...)`, `booleanArrayOf(...)`, `charArrayOf(...)` |
 
@@ -366,9 +371,22 @@ That is not true for single source projects, like [test-project](./test-project)
 - For KSP, for the entire printed object to be a valid constructor call, all classes in the hierarchy must be annotated.
 - For KSP, if an annotated data class has a property of a non-annotated class, the property's value is printed with a 
   standard `toString()`.
-- Not all collection types are supported yet. See
+- Not all collection types are supported. See
   [KSP and Collection Types](#KSP-and-Collection-Types) for what KSP handles, and
   [Reflection and Collection Types](#Reflection-and-Collection-Types) for reflection.
+  Still missing, in both implementations:
+  - `Collection`, `Iterable` and `Sequence` properties, and `Pair` and `Triple`.
+    These fall back to `toString()`, so the output is readable but is not a
+    constructor call.
+  - Nested collections, eg. `List<List<Int>>` or `Map<String, List<Int>>` with a
+    collection value. The outer collection prints correctly, but the inner one prints
+    via `toString()` as `[0, 1]`, which is not valid Kotlin.
+  - The unsigned arrays `UByteArray`, `UShortArray`, `UIntArray` and `ULongArray`.
+  - A property whose type is a `typealias` for a `@DeepPrint` `data class`. The alias
+    is not resolved, so the property falls back to `toString()`.
+- Nullable properties are not supported. A `val items: List<Int>?` generates code that
+  does not compile. This is not specific to collections: `val name: String?` has the
+  same problem.
 - On Kotlin/JS, `Float`, `Double` and `Char` elements of a `List`, `Set` or `Array` are
   identified by their runtime type, which JS erases to a number. `2.0f` prints as `2` and
   `'A'` prints as `65`. `FloatArray`, `DoubleArray` and `CharArray` are not affected, and

--- a/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
+++ b/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
@@ -60,16 +60,41 @@ fun <K, V> Map<K, V>.deepPrintContents(
     return stringBuilder.toString()
 }
 
-fun <T> List<T>.deepPrintContents(): String {
+private inline fun <T> Iterable<T>.deepPrintItems(transform: (T) -> String): String {
     val stringBuilder = StringBuilder()
     this.forEach { value ->
-        val toAdd = deepPrintPrimitive(value)
-        stringBuilder.append(" $toAdd,")
+        stringBuilder.append(" ${transform(value)},")
     }
     return stringBuilder.toString()
 }
 
-fun <T> Array<T>.deepPrintContents(): String = this.toList().deepPrintContents()
+fun <T> List<T>.deepPrintContents(): String = deepPrintItems { deepPrintPrimitive(it) }
+
+fun <T> Set<T>.deepPrintContents(): String = deepPrintItems { deepPrintPrimitive(it) }
+
+fun <T> Array<T>.deepPrintContents(): String = asIterable().deepPrintItems { deepPrintPrimitive(it) }
+
+/*
+ * The primitive arrays dispatch on the static element type rather than going through
+ * deepPrintPrimitive(). Kotlin/JS compiles Float, Double and Char down to plain numbers,
+ * so a runtime `is Float` / `is Char` check there would print 2.0f as `2` and 'A' as `65`.
+ */
+
+fun ByteArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+fun ShortArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+fun IntArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+fun LongArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+fun FloatArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+fun DoubleArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+fun BooleanArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+fun CharArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
 
 /**
  * In jvm, android, and native platforms, printing 2.0f

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
@@ -53,6 +53,21 @@ class DeepPrintProcessor(
     companion object {
         private const val DATACLASS_MAP_VAL_INDENT_MULTIPLIER = 3
         private const val PRIMITIVE_MAP_VAL_INDENT_MUTILPLIER = 2
+
+        /**
+         * Primitive arrays are not `Array<T>`: they carry no type argument and each
+         * has its own factory function.
+         */
+        private val PRIMITIVE_ARRAY_CONSTRUCTORS = mapOf(
+            "ByteArray" to "byteArrayOf",
+            "ShortArray" to "shortArrayOf",
+            "IntArray" to "intArrayOf",
+            "LongArray" to "longArrayOf",
+            "FloatArray" to "floatArrayOf",
+            "DoubleArray" to "doubleArrayOf",
+            "BooleanArray" to "booleanArrayOf",
+            "CharArray" to "charArrayOf",
+        )
     }
     /**
      * Files already written in this processing run, so that a class reached through
@@ -118,9 +133,12 @@ class DeepPrintProcessor(
             props: Sequence<KSPropertyDeclaration>
         ): String {
             val packageStringBuilder = StringBuilder()
-            val importsStringBuilder = StringBuilder()
-            importsStringBuilder.append("import com.bradyaiello.deepprint.deepPrint\n")
-            importsStringBuilder.append("import com.bradyaiello.deepprint.indent\n")
+            // A set: a class with several collection properties would otherwise
+            // repeat the same import once per property.
+            val imports = linkedSetOf(
+                "import com.bradyaiello.deepprint.deepPrint",
+                "import com.bradyaiello.deepprint.indent",
+            )
             val functionStringBuilder = StringBuilder()
 
             if (classDeclaration.isDataClass()) {
@@ -138,16 +156,19 @@ class DeepPrintProcessor(
                     val propertyAssignment = when (type.declaration.simpleName.asString()) {
                         "String", "Byte", "Short", "Int", "Long", "Boolean", "Char",
                         "Double", "Float" -> "\${${propertyDeclaration}.deepPrint()},\n"
-                        "List", "Array", "MutableList" -> {
-                            processList(importsStringBuilder, type, propertyDeclaration)
+                        "List", "MutableList", "Set", "MutableSet", "Array" -> {
+                            processCollection(imports, type, propertyDeclaration)
+                        }
+                        in PRIMITIVE_ARRAY_CONSTRUCTORS -> {
+                            processPrimitiveArray(imports, type, propertyDeclaration)
                         }
                         "Map", "MutableMap" -> {
-                            processMap(importsStringBuilder, type, propertyDeclaration)
+                            processMap(imports, type, propertyDeclaration)
                         }
                         // Property assignment is an annotated data class (can deep print), 
                         // or not (cannot deep print)
                         else -> {
-                            processAnnotatedDataClassOrNotSupported(type, propertyDeclaration, importsStringBuilder)
+                            processAnnotatedDataClassOrNotSupported(type, propertyDeclaration, imports)
                         }
                     }
                     functionStringBuilder.append(propertyAssignment)
@@ -158,7 +179,7 @@ class DeepPrintProcessor(
             }
 
             return packageStringBuilder.toString() +
-                    importsStringBuilder.toString() +
+                    imports.joinToString(separator = "") { "$it\n" } +
                     functionStringBuilder.toString()
         }
 
@@ -166,7 +187,7 @@ class DeepPrintProcessor(
         private fun processAnnotatedDataClassOrNotSupported(
             type: KSType,
             propertyDeclaration: KSPropertyDeclaration,
-            importsStringBuilder: StringBuilder
+            imports: MutableSet<String>
         ): String {
             val propClassDeclaration = type.declaration as? KSClassDeclaration
             val propPackage = propClassDeclaration!!.packageName
@@ -176,7 +197,7 @@ class DeepPrintProcessor(
                 (propClassDeclaration.isAnnotationPresent(DeepPrint::class) ||
                         propertyDeclaration.isAnnotationPresent(DeepPrint::class))
             ) {
-                importsStringBuilder.append("import $propPackageName.deepPrint\n")
+                imports.add("import $propPackageName.deepPrint")
                 "\n\${${propertyDeclaration}.deepPrint(currentIndent + 2 * indentWidth)},\n"
             } else { /* no annotation on property or class */
                 "\$$propertyDeclaration,\n"
@@ -184,11 +205,11 @@ class DeepPrintProcessor(
         }
 
         private fun processMap(
-            importsStringBuilder: StringBuilder,
+            imports: MutableSet<String>,
             type: KSType,
             propertyDeclaration: KSPropertyDeclaration
         ): String {
-            importsStringBuilder.append("import com.bradyaiello.deepprint.deepPrintContents\n")
+            imports.add("import com.bradyaiello.deepprint.deepPrintContents")
             val ksKeyTypeRef: KSTypeReference = type.arguments[0].type!!
             val ksValueTypeRef: KSTypeReference = type.arguments[1].type!!
             val valueDecl = ksValueTypeRef.resolve().declaration
@@ -212,35 +233,53 @@ class DeepPrintProcessor(
         }
 
         /**
-         * Processes collection types List, MutableList, Array
-         * Returns the expression as {listOf(), mutableListOf(), 
-         * or arrayOf() function calls.
+         * Processes the collection types that take a single type argument:
+         * List, MutableList, Set, MutableSet and Array.
+         * Returns the expression as a listOf(), mutableListOf(), setOf(),
+         * mutableSetOf() or arrayOf() function call.
          */
         @OptIn(KspExperimental::class)
-        private fun processList(
-            importsStringBuilder: StringBuilder,
+        private fun processCollection(
+            imports: MutableSet<String>,
             type: KSType,
             propertyDeclaration: KSPropertyDeclaration
         ): String {
-            importsStringBuilder.append("import com.bradyaiello.deepprint.deepPrintContents\n")
+            imports.add("import com.bradyaiello.deepprint.deepPrintContents")
             val ksTypeArg = type.arguments[0]
-            val listType = ksTypeArg.type!!
+            val itemType = ksTypeArg.type!!
             val paramHasDeepPrintAnnotation =
                 ksTypeArg.type!!.resolve().declaration.isAnnotationPresent(DeepPrint::class)
-            val listConstructor = when (type.declaration.simpleName.asString()) {
+            val collectionConstructor = when (type.declaration.simpleName.asString()) {
                 "MutableList" -> "mutableListOf"
                 "List" -> "listOf"
+                "MutableSet" -> "mutableSetOf"
+                "Set" -> "setOf"
                 else -> "arrayOf"
             }
-            val opening = "$listConstructor<${listType}>("
+            val opening = "$collectionConstructor<${itemType}>("
             val itemsPrint: String = if (paramHasDeepPrintAnnotation) {
-                "\n\${$propertyDeclaration.map{ it.deepPrint(currentIndent = " +
-                        "currentIndent + 2 * indentWidth) +\",\\n\"}" +
-                        ".reduce {acc, item -> acc + item}}\${(currentIndent + indentWidth).indent()}),\n"
+                "\n\${$propertyDeclaration.joinToString(separator = \"\") " +
+                        "{ it.deepPrint(currentIndent = currentIndent + 2 * indentWidth) + \",\\n\" }}" +
+                        "\${(currentIndent + indentWidth).indent()}),\n"
             } else {
                 "\${$propertyDeclaration.deepPrintContents()}),\n"
             }
             return opening + itemsPrint
+        }
+
+        /**
+         * Processes IntArray, LongArray and friends. They have no type argument,
+         * so the element type is baked into the factory function name.
+         */
+        private fun processPrimitiveArray(
+            imports: MutableSet<String>,
+            type: KSType,
+            propertyDeclaration: KSPropertyDeclaration
+        ): String {
+            imports.add("import com.bradyaiello.deepprint.deepPrintContents")
+            val arrayConstructor =
+                PRIMITIVE_ARRAY_CONSTRUCTORS.getValue(type.declaration.simpleName.asString())
+            return "$arrayConstructor(\${$propertyDeclaration.deepPrintContents()}),\n"
         }
 
         private fun KSDeclaration.isDeepPrintAnnotatedDataClass(): Boolean {

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
@@ -133,8 +133,10 @@ class DeepPrintProcessor(
             props: Sequence<KSPropertyDeclaration>
         ): String {
             val packageStringBuilder = StringBuilder()
-            // A set: a class with several collection properties would otherwise
-            // repeat the same import once per property.
+            // A set, because a class with several collection properties would otherwise
+            // repeat the same import once per property. LinkedHashSet rather than
+            // MutableSet: the generated file has to come out byte-identical every run,
+            // so insertion order has to be part of the contract.
             val imports = linkedSetOf(
                 "import com.bradyaiello.deepprint.deepPrint",
                 "import com.bradyaiello.deepprint.indent",
@@ -156,13 +158,14 @@ class DeepPrintProcessor(
                     val propertyAssignment = when (type.declaration.simpleName.asString()) {
                         "String", "Byte", "Short", "Int", "Long", "Boolean", "Char",
                         "Double", "Float" -> "\${${propertyDeclaration}.deepPrint()},\n"
-                        "List", "MutableList", "Set", "MutableSet", "Array" -> {
+                        "List", "MutableList", "ArrayList",
+                        "Set", "MutableSet", "HashSet", "LinkedHashSet", "Array" -> {
                             processCollection(imports, type, propertyDeclaration)
                         }
                         in PRIMITIVE_ARRAY_CONSTRUCTORS -> {
                             processPrimitiveArray(imports, type, propertyDeclaration)
                         }
-                        "Map", "MutableMap" -> {
+                        "Map", "MutableMap", "HashMap", "LinkedHashMap" -> {
                             processMap(imports, type, propertyDeclaration)
                         }
                         // Property assignment is an annotated data class (can deep print), 
@@ -187,10 +190,14 @@ class DeepPrintProcessor(
         private fun processAnnotatedDataClassOrNotSupported(
             type: KSType,
             propertyDeclaration: KSPropertyDeclaration,
-            imports: MutableSet<String>
+            imports: LinkedHashSet<String>
         ): String {
+            // Not every declaration is a class: a typealias resolves to a KSTypeAlias.
+            // There is nothing to deep print in that case, so fall back to toString()
+            // the same way an unannotated class does, rather than throwing.
             val propClassDeclaration = type.declaration as? KSClassDeclaration
-            val propPackage = propClassDeclaration!!.packageName
+                ?: return "\$$propertyDeclaration,\n"
+            val propPackage = propClassDeclaration.packageName
             val propPackageName = propPackage.asString()
             // TODO(Support properties defined outside of the module)
             return if (propClassDeclaration.isDataClass() &&
@@ -205,7 +212,7 @@ class DeepPrintProcessor(
         }
 
         private fun processMap(
-            imports: MutableSet<String>,
+            imports: LinkedHashSet<String>,
             type: KSType,
             propertyDeclaration: KSPropertyDeclaration
         ): String {
@@ -215,6 +222,8 @@ class DeepPrintProcessor(
             val valueDecl = ksValueTypeRef.resolve().declaration
             val mapConstructor = when (type.declaration.simpleName.asString()) {
                 "Map" -> "mapOf"
+                "HashMap" -> "hashMapOf"
+                "LinkedHashMap" -> "linkedMapOf"
                 else  -> "mutableMapOf"
             }
             val opening = "$mapConstructor<$ksKeyTypeRef,$ksValueTypeRef>(\n"
@@ -240,7 +249,7 @@ class DeepPrintProcessor(
          */
         @OptIn(KspExperimental::class)
         private fun processCollection(
-            imports: MutableSet<String>,
+            imports: LinkedHashSet<String>,
             type: KSType,
             propertyDeclaration: KSPropertyDeclaration
         ): String {
@@ -252,8 +261,11 @@ class DeepPrintProcessor(
             val collectionConstructor = when (type.declaration.simpleName.asString()) {
                 "MutableList" -> "mutableListOf"
                 "List" -> "listOf"
+                "ArrayList" -> "arrayListOf"
                 "MutableSet" -> "mutableSetOf"
                 "Set" -> "setOf"
+                "HashSet" -> "hashSetOf"
+                "LinkedHashSet" -> "linkedSetOf"
                 else -> "arrayOf"
             }
             val opening = "$collectionConstructor<${itemType}>("
@@ -272,7 +284,7 @@ class DeepPrintProcessor(
          * so the element type is baked into the factory function name.
          */
         private fun processPrimitiveArray(
-            imports: MutableSet<String>,
+            imports: LinkedHashSet<String>,
             type: KSType,
             propertyDeclaration: KSPropertyDeclaration
         ): String {

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -84,6 +84,36 @@ data class WithDeepPrintableArray(
 )
 
 @DeepPrint
+data class WithASet(val name: String, val items: Set<Int>)
+
+@DeepPrint
+data class WithAMutableSet(val name: String, val items: MutableSet<Int>)
+
+@DeepPrint
+data class WithDeepPrintableSet(
+    val name: String,
+    val surfers: Set<Surfer>
+)
+
+@DeepPrint
+data class WithDeepPrintableMutableSet(
+    val name: String,
+    val surfers: MutableSet<Surfer>
+)
+
+@DeepPrint
+data class WithPrimitiveArrays(
+    val bytes: ByteArray,
+    val shorts: ShortArray,
+    val ints: IntArray,
+    val longs: LongArray,
+    val floats: FloatArray,
+    val doubles: DoubleArray,
+    val booleans: BooleanArray,
+    val chars: CharArray,
+)
+
+@DeepPrint
 data class WithAMap(
     val id: Long,
     val someMap: Map<Int, String>

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -113,6 +113,20 @@ data class WithPrimitiveArrays(
     val chars: CharArray,
 )
 
+typealias PersonAlias = SamplePersonClass
+
+@DeepPrint
+data class WithJdkCollections(
+    val arrayList: ArrayList<Int>,
+    val linkedSet: LinkedHashSet<Int>,
+    val linkedMap: LinkedHashMap<Int, String>,
+    val hashSet: HashSet<Int>,
+    val hashMap: HashMap<Int, String>,
+)
+
+@DeepPrint
+data class WithTypeAliasProperty(val person: PersonAlias)
+
 @DeepPrint
 data class WithAMap(
     val id: Long,

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -24,9 +24,11 @@ import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableSet
+import com.bradyaiello.deepprint.testclasses.WithJdkCollections
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithPrimitiveArrays
+import com.bradyaiello.deepprint.testclasses.WithTypeAliasProperty
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 
@@ -156,6 +158,17 @@ val withPrimitiveArrays = WithPrimitiveArrays(
     booleans = booleanArrayOf(true, false),
     chars = charArrayOf('A', 'B'),
 )
+
+val withJdkCollections = WithJdkCollections(
+    arrayList = arrayListOf(0, 1, 2),
+    linkedSet = linkedSetOf(0, 1, 2),
+    linkedMap = linkedMapOf(1 to "a", 2 to "b"),
+    // Single entry: HashSet and HashMap have no order guarantee across platforms.
+    hashSet = hashSetOf(7),
+    hashMap = hashMapOf(7 to "seven"),
+)
+
+val withTypeAliasProperty = WithTypeAliasProperty(person = person)
 
 val withAnnotatedProperty = WithAnnotatedProperty(
     label = "some label",

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -15,13 +15,18 @@ import com.bradyaiello.deepprint.testclasses.WithAList
 import com.bradyaiello.deepprint.testclasses.WithAMap
 import com.bradyaiello.deepprint.testclasses.WithAMutableList
 import com.bradyaiello.deepprint.testclasses.WithAMutableMap
+import com.bradyaiello.deepprint.testclasses.WithAMutableSet
+import com.bradyaiello.deepprint.testclasses.WithASet
 import com.bradyaiello.deepprint.testclasses.WithAnArray
 import com.bradyaiello.deepprint.testclasses.WithAnnotatedProperty
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableArray
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
+import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableSet
+import com.bradyaiello.deepprint.testclasses.WithDeepPrintableSet
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
+import com.bradyaiello.deepprint.testclasses.WithPrimitiveArrays
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 
@@ -124,6 +129,33 @@ val withDeepPrintableList = WithDeepPrintableList("a name", listOf(surfer, surfe
 val withDeepPrintableMutableList = WithDeepPrintableMutableList("a name", mutableListOf(surfer, surfer2))
 
 val withDeepPrintableArray = WithDeepPrintableArray("a name", arrayOf(surfer, surfer2))
+
+val withASet = WithASet(
+    name = "some set",
+    items = setOf<Int>(0, 1, 2, 3, 4)
+)
+
+val withAMutableSet = WithAMutableSet(
+    name = "some set",
+    items = mutableSetOf<Int>(0, 1, 2, 3, 4)
+)
+
+val withDeepPrintableSet = WithDeepPrintableSet("a name", setOf(surfer, surfer2))
+
+val withDeepPrintableMutableSet = WithDeepPrintableMutableSet("a name", mutableSetOf(surfer, surfer2))
+
+val withAnEmptyDeepPrintableSet = WithDeepPrintableSet("a name", emptySet())
+
+val withPrimitiveArrays = WithPrimitiveArrays(
+    bytes = byteArrayOf(-1, 0, 1),
+    shorts = shortArrayOf(2, 3),
+    ints = intArrayOf(0, 1, 2, 3, 4),
+    longs = longArrayOf(1000L, 2000L),
+    floats = floatArrayOf(1234f, 2.5f),
+    doubles = doubleArrayOf(56789.0, 0.5),
+    booleans = booleanArrayOf(true, false),
+    chars = charArrayOf('A', 'B'),
+)
 
 val withAnnotatedProperty = WithAnnotatedProperty(
     label = "some label",

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -13,11 +13,17 @@ import com.bradyaiello.deepprint.testobjects.withAMapDataClasses
 import com.bradyaiello.deepprint.testobjects.withAMutableList
 import com.bradyaiello.deepprint.testobjects.withAMutableMap
 import com.bradyaiello.deepprint.testobjects.withAMutableMapDataClasses
+import com.bradyaiello.deepprint.testobjects.withAMutableSet
+import com.bradyaiello.deepprint.testobjects.withASet
 import com.bradyaiello.deepprint.testobjects.withAnArray
+import com.bradyaiello.deepprint.testobjects.withAnEmptyDeepPrintableSet
 import com.bradyaiello.deepprint.testobjects.withAnnotatedProperty
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableArray
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableList
+import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableSet
+import com.bradyaiello.deepprint.testobjects.withDeepPrintableSet
+import com.bradyaiello.deepprint.testobjects.withPrimitiveArrays
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -231,6 +237,129 @@ class BasicTest {
         """.trimIndent()
 
         val actual = withDeepPrintableArray.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deepPrintableIntSet() {
+        val expected = """
+            WithASet(
+              name = "some set",
+              items = setOf<Int>( 0, 1, 2, 3, 4,),
+            )
+        """.trimIndent()
+
+        val actual = withASet.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deepPrintableIntMutableSet() {
+        val expected = """
+            WithAMutableSet(
+              name = "some set",
+              items = mutableSetOf<Int>( 0, 1, 2, 3, 4,),
+            )
+        """.trimIndent()
+
+        val actual = withAMutableSet.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deepPrintableSet() {
+        val expected = """
+            WithDeepPrintableSet(
+              name = "a name",
+              surfers = setOf<Surfer>(
+                Surfer(
+                  name = "Honolua Blomfield",
+                  surfboard = 
+                    Surfboard(
+                      length = 11.5f,
+                      width = 2.0f,
+                      style = "longboard",
+                    ),
+                ),
+                Surfer(
+                  name = "Kelly Slater",
+                  surfboard = 
+                    Surfboard(
+                      length = 5.9f,
+                      width = 1.8f,
+                      style = "shortboard",
+                    ),
+                ),
+              ),
+            )
+        """.trimIndent()
+
+        val actual = withDeepPrintableSet.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deepPrintableMutableSet() {
+        val expected = """
+            WithDeepPrintableMutableSet(
+              name = "a name",
+              surfers = mutableSetOf<Surfer>(
+                Surfer(
+                  name = "Honolua Blomfield",
+                  surfboard = 
+                    Surfboard(
+                      length = 11.5f,
+                      width = 2.0f,
+                      style = "longboard",
+                    ),
+                ),
+                Surfer(
+                  name = "Kelly Slater",
+                  surfboard = 
+                    Surfboard(
+                      length = 5.9f,
+                      width = 1.8f,
+                      style = "shortboard",
+                    ),
+                ),
+              ),
+            )
+        """.trimIndent()
+
+        val actual = withDeepPrintableMutableSet.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun emptyDeepPrintableSet() {
+        val expected = """
+            WithDeepPrintableSet(
+              name = "a name",
+              surfers = setOf<Surfer>(
+              ),
+            )
+        """.trimIndent()
+
+        val actual = withAnEmptyDeepPrintableSet.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun primitiveArrays() {
+        val expected = """
+            WithPrimitiveArrays(
+              bytes = byteArrayOf( -1, 0, 1,),
+              shorts = shortArrayOf( 2, 3,),
+              ints = intArrayOf( 0, 1, 2, 3, 4,),
+              longs = longArrayOf( 1000, 2000,),
+              floats = floatArrayOf( 1234.0f, 2.5f,),
+              doubles = doubleArrayOf( 56789.0, 0.5,),
+              booleans = booleanArrayOf( true, false,),
+              chars = charArrayOf( 'A', 'B',),
+            )
+        """.trimIndent()
+
+        val actual = withPrimitiveArrays.deepPrint()
         assertEquals(expected, actual)
     }
 

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -23,7 +23,9 @@ import com.bradyaiello.deepprint.testobjects.withDeepPrintableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableSet
+import com.bradyaiello.deepprint.testobjects.withJdkCollections
 import com.bradyaiello.deepprint.testobjects.withPrimitiveArrays
+import com.bradyaiello.deepprint.testobjects.withTypeAliasProperty
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -360,6 +362,41 @@ class BasicTest {
         """.trimIndent()
 
         val actual = withPrimitiveArrays.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun jdkCollectionTypes() {
+        val expected = """
+            WithJdkCollections(
+              arrayList = arrayListOf<Int>( 0, 1, 2,),
+              linkedSet = linkedSetOf<Int>( 0, 1, 2,),
+              linkedMap = linkedMapOf<Int,String>(
+                1 to "a",
+                2 to "b",
+              ),
+              hashSet = hashSetOf<Int>( 7,),
+              hashMap = hashMapOf<Int,String>(
+                7 to "seven",
+              ),
+            )
+        """.trimIndent()
+
+        val actual = withJdkCollections.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun typeAliasPropertyFallsBackToToString() {
+        // A typealias resolves to a KSTypeAlias, not a class declaration, so there is
+        // nothing to deep print. What matters here is that it does not throw.
+        val expected = """
+            WithTypeAliasProperty(
+              person = SamplePersonClass(name=Dave, sampleClass=SampleClass(x=0.5, y=2.6, name=A point)),
+            )
+        """.trimIndent()
+
+        val actual = withTypeAliasProperty.deepPrint()
         assertEquals(expected, actual)
     }
 

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -23,7 +23,9 @@ import com.bradyaiello.deepprint.testobjects.withDeepPrintableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableSet
+import com.bradyaiello.deepprint.testobjects.withJdkCollections
 import com.bradyaiello.deepprint.testobjects.withPrimitiveArrays
+import com.bradyaiello.deepprint.testobjects.withTypeAliasProperty
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -360,6 +362,41 @@ class BasicTest {
         """.trimIndent()
 
         val actual = withPrimitiveArrays.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun jdkCollectionTypes() {
+        val expected = """
+            WithJdkCollections(
+                arrayList = arrayListOf<Int>( 0, 1, 2,),
+                linkedSet = linkedSetOf<Int>( 0, 1, 2,),
+                linkedMap = linkedMapOf<Int,String>(
+                    1 to "a",
+                    2 to "b",
+                ),
+                hashSet = hashSetOf<Int>( 7,),
+                hashMap = hashMapOf<Int,String>(
+                    7 to "seven",
+                ),
+            )
+        """.trimIndent()
+
+        val actual = withJdkCollections.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun typeAliasPropertyFallsBackToToString() {
+        // A typealias resolves to a KSTypeAlias, not a class declaration, so there is
+        // nothing to deep print. What matters here is that it does not throw.
+        val expected = """
+            WithTypeAliasProperty(
+                person = SamplePersonClass(name=Dave, sampleClass=SampleClass(x=0.5, y=2.6, name=A point)),
+            )
+        """.trimIndent()
+
+        val actual = withTypeAliasProperty.deepPrint()
         assertEquals(expected, actual)
     }
 

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -13,11 +13,17 @@ import com.bradyaiello.deepprint.testobjects.withAMapDataClasses
 import com.bradyaiello.deepprint.testobjects.withAMutableList
 import com.bradyaiello.deepprint.testobjects.withAMutableMap
 import com.bradyaiello.deepprint.testobjects.withAMutableMapDataClasses
+import com.bradyaiello.deepprint.testobjects.withAMutableSet
+import com.bradyaiello.deepprint.testobjects.withASet
 import com.bradyaiello.deepprint.testobjects.withAnArray
+import com.bradyaiello.deepprint.testobjects.withAnEmptyDeepPrintableSet
 import com.bradyaiello.deepprint.testobjects.withAnnotatedProperty
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableArray
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableList
+import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableSet
+import com.bradyaiello.deepprint.testobjects.withDeepPrintableSet
+import com.bradyaiello.deepprint.testobjects.withPrimitiveArrays
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -231,6 +237,129 @@ class BasicTest {
         """.trimIndent()
 
         val actual = withDeepPrintableArray.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deepPrintableIntSet() {
+        val expected = """
+            WithASet(
+                name = "some set",
+                items = setOf<Int>( 0, 1, 2, 3, 4,),
+            )
+        """.trimIndent()
+
+        val actual = withASet.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deepPrintableIntMutableSet() {
+        val expected = """
+            WithAMutableSet(
+                name = "some set",
+                items = mutableSetOf<Int>( 0, 1, 2, 3, 4,),
+            )
+        """.trimIndent()
+
+        val actual = withAMutableSet.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deepPrintableSet() {
+        val expected = """
+            WithDeepPrintableSet(
+                name = "a name",
+                surfers = setOf<Surfer>(
+                    Surfer(
+                        name = "Honolua Blomfield",
+                        surfboard = 
+                            Surfboard(
+                                length = 11.5f,
+                                width = 2.0f,
+                                style = "longboard",
+                            ),
+                    ),
+                    Surfer(
+                        name = "Kelly Slater",
+                        surfboard = 
+                            Surfboard(
+                                length = 5.9f,
+                                width = 1.8f,
+                                style = "shortboard",
+                            ),
+                    ),
+                ),
+            )
+        """.trimIndent()
+
+        val actual = withDeepPrintableSet.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deepPrintableMutableSet() {
+        val expected = """
+            WithDeepPrintableMutableSet(
+                name = "a name",
+                surfers = mutableSetOf<Surfer>(
+                    Surfer(
+                        name = "Honolua Blomfield",
+                        surfboard = 
+                            Surfboard(
+                                length = 11.5f,
+                                width = 2.0f,
+                                style = "longboard",
+                            ),
+                    ),
+                    Surfer(
+                        name = "Kelly Slater",
+                        surfboard = 
+                            Surfboard(
+                                length = 5.9f,
+                                width = 1.8f,
+                                style = "shortboard",
+                            ),
+                    ),
+                ),
+            )
+        """.trimIndent()
+
+        val actual = withDeepPrintableMutableSet.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun emptyDeepPrintableSet() {
+        val expected = """
+            WithDeepPrintableSet(
+                name = "a name",
+                surfers = setOf<Surfer>(
+                ),
+            )
+        """.trimIndent()
+
+        val actual = withAnEmptyDeepPrintableSet.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun primitiveArrays() {
+        val expected = """
+            WithPrimitiveArrays(
+                bytes = byteArrayOf( -1, 0, 1,),
+                shorts = shortArrayOf( 2, 3,),
+                ints = intArrayOf( 0, 1, 2, 3, 4,),
+                longs = longArrayOf( 1000, 2000,),
+                floats = floatArrayOf( 1234.0f, 2.5f,),
+                doubles = doubleArrayOf( 56789.0, 0.5,),
+                booleans = booleanArrayOf( true, false,),
+                chars = charArrayOf( 'A', 'B',),
+            )
+        """.trimIndent()
+
+        val actual = withPrimitiveArrays.deepPrint()
         assertEquals(expected, actual)
     }
 

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -112,6 +112,20 @@ data class WithPrimitiveArrays(
     val chars: CharArray,
 )
 
+typealias PersonAlias = SamplePersonClass
+
+@DeepPrint
+data class WithJdkCollections(
+    val arrayList: ArrayList<Int>,
+    val linkedSet: LinkedHashSet<Int>,
+    val linkedMap: LinkedHashMap<Int, String>,
+    val hashSet: HashSet<Int>,
+    val hashMap: HashMap<Int, String>,
+)
+
+@DeepPrint
+data class WithTypeAliasProperty(val person: PersonAlias)
+
 @DeepPrint
 data class WithAMap(
     val id: Long,

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -83,6 +83,36 @@ data class WithDeepPrintableArray(
 )
 
 @DeepPrint
+data class WithASet(val name: String, val items: Set<Int>)
+
+@DeepPrint
+data class WithAMutableSet(val name: String, val items: MutableSet<Int>)
+
+@DeepPrint
+data class WithDeepPrintableSet(
+    val name: String,
+    val surfers: Set<Surfer>
+)
+
+@DeepPrint
+data class WithDeepPrintableMutableSet(
+    val name: String,
+    val surfers: MutableSet<Surfer>
+)
+
+@DeepPrint
+data class WithPrimitiveArrays(
+    val bytes: ByteArray,
+    val shorts: ShortArray,
+    val ints: IntArray,
+    val longs: LongArray,
+    val floats: FloatArray,
+    val doubles: DoubleArray,
+    val booleans: BooleanArray,
+    val chars: CharArray,
+)
+
+@DeepPrint
 data class WithAMap(
     val id: Long,
     val someMap: Map<Int, String>

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -24,9 +24,11 @@ import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableSet
+import com.bradyaiello.deepprint.testclasses.WithJdkCollections
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithPrimitiveArrays
+import com.bradyaiello.deepprint.testclasses.WithTypeAliasProperty
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 
@@ -156,6 +158,17 @@ val withPrimitiveArrays = WithPrimitiveArrays(
     booleans = booleanArrayOf(true, false),
     chars = charArrayOf('A', 'B'),
 )
+
+val withJdkCollections = WithJdkCollections(
+    arrayList = arrayListOf(0, 1, 2),
+    linkedSet = linkedSetOf(0, 1, 2),
+    linkedMap = linkedMapOf(1 to "a", 2 to "b"),
+    // Single entry: HashSet and HashMap have no order guarantee across platforms.
+    hashSet = hashSetOf(7),
+    hashMap = hashMapOf(7 to "seven"),
+)
+
+val withTypeAliasProperty = WithTypeAliasProperty(person = person)
 
 val withAnnotatedProperty = WithAnnotatedProperty(
     label = "some label",

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -15,13 +15,18 @@ import com.bradyaiello.deepprint.testclasses.WithAList
 import com.bradyaiello.deepprint.testclasses.WithAMap
 import com.bradyaiello.deepprint.testclasses.WithAMutableList
 import com.bradyaiello.deepprint.testclasses.WithAMutableMap
+import com.bradyaiello.deepprint.testclasses.WithAMutableSet
+import com.bradyaiello.deepprint.testclasses.WithASet
 import com.bradyaiello.deepprint.testclasses.WithAnArray
 import com.bradyaiello.deepprint.testclasses.WithAnnotatedProperty
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableArray
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
+import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableSet
+import com.bradyaiello.deepprint.testclasses.WithDeepPrintableSet
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
+import com.bradyaiello.deepprint.testclasses.WithPrimitiveArrays
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 
@@ -124,6 +129,33 @@ val withDeepPrintableList = WithDeepPrintableList("a name", listOf(surfer, surfe
 val withDeepPrintableMutableList = WithDeepPrintableMutableList("a name", mutableListOf(surfer, surfer2))
 
 val withDeepPrintableArray = WithDeepPrintableArray("a name", arrayOf(surfer, surfer2))
+
+val withASet = WithASet(
+    name = "some set",
+    items = setOf<Int>(0, 1, 2, 3, 4)
+)
+
+val withAMutableSet = WithAMutableSet(
+    name = "some set",
+    items = mutableSetOf<Int>(0, 1, 2, 3, 4)
+)
+
+val withDeepPrintableSet = WithDeepPrintableSet("a name", setOf(surfer, surfer2))
+
+val withDeepPrintableMutableSet = WithDeepPrintableMutableSet("a name", mutableSetOf(surfer, surfer2))
+
+val withAnEmptyDeepPrintableSet = WithDeepPrintableSet("a name", emptySet())
+
+val withPrimitiveArrays = WithPrimitiveArrays(
+    bytes = byteArrayOf(-1, 0, 1),
+    shorts = shortArrayOf(2, 3),
+    ints = intArrayOf(0, 1, 2, 3, 4),
+    longs = longArrayOf(1000L, 2000L),
+    floats = floatArrayOf(1234f, 2.5f),
+    doubles = doubleArrayOf(56789.0, 0.5),
+    booleans = booleanArrayOf(true, false),
+    chars = charArrayOf('A', 'B'),
+)
 
 val withAnnotatedProperty = WithAnnotatedProperty(
     label = "some label",


### PR DESCRIPTION
Adds five collection types to the KSP code generator.

| Property type | Printed as |
| --- | --- |
| `Set<T>` | `setOf<T>(...)` |
| `MutableSet<T>` | `mutableSetOf<T>(...)` |
| `ByteArray`, `ShortArray`, `IntArray`, `LongArray` | `byteArrayOf(...)`, `shortArrayOf(...)`, `intArrayOf(...)`, `longArrayOf(...)` |
| `FloatArray`, `DoubleArray`, `BooleanArray`, `CharArray` | `floatArrayOf(...)`, `doubleArrayOf(...)`, `booleanArrayOf(...)`, `charArrayOf(...)` |
| `ArrayList<T>` | `arrayListOf<T>(...)` |
| `HashSet<T>`, `LinkedHashSet<T>` | `hashSetOf<T>(...)`, `linkedSetOf<T>(...)` |
| `HashMap<K, V>`, `LinkedHashMap<K, V>` | `hashMapOf<K, V>(...)`, `linkedMapOf<K, V>(...)` |

Sets take the same path as `List`/`MutableList`/`Array` — `processList` is renamed `processCollection` — so their elements can be primitives or annotated data classes, and a `Set` prints as `setOf()` while a `MutableSet` prints as `mutableSetOf()` (the reflection implementation can't tell those apart, KSP can).

Primitive arrays need their own path: they carry no type argument, and each has its own factory function.

## The Kotlin/JS bug the new tests found

The primitive-array helpers in `Utils.kt` dispatch on the **static** element type rather than going through `deepPrintPrimitive()`. Kotlin/JS compiles `Float`, `Double` and `Char` down to plain numbers, so a runtime `is Float` / `is Char` check picks the wrong branch there. Before the fix, `jsNodeTest` produced:

```
floats = floatArrayOf( 1234, 2.5,),      // expected 1234.0f, 2.5f
chars  = charArrayOf( '65', '66',),      // expected 'A', 'B'
```

`FloatArray`, `DoubleArray` and `CharArray` are now correct on JS. The same limitation still applies to `Float`/`Double`/`Char` elements inside a generic `List`, `Set` or `Array`, which is pre-existing — it's written down under *Current Limitations* now rather than silently producing bad output.

## A crash, fixed

`ArrayList<Int>` and `HashSet<Int>` as `data class` properties crashed the processor:

```
e: [ksp] java.lang.NullPointerException
```

They're typealiases in the Kotlin stdlib, so `KSType.declaration` is a `KSTypeAlias`, not a `KSClassDeclaration`, and `processAnnotatedDataClassOrNotSupported` forced the failed cast with `!!`. This reproduces on unmodified `main` — it isn't new to this branch, but it's squarely in this PR's territory, so it's fixed here. The failed cast now falls back to `toString()`, which is already what an unannotated class property does. Any user-defined typealias hit that same `!!`, so there's a test for that path too.

The five concrete JDK collection types then get real factory functions rather than the fallback, which is why they're in the table above.

## Two fixes the new tests surfaced

- **Empty collections of annotated data classes threw.** The generated code joined elements with `map { }.reduce { }`, and `reduce` throws `UnsupportedOperationException` on an empty collection. It's `joinToString` now, and `emptyDeepPrintableSet` covers it. Output for non-empty collections is byte-identical.
- **Duplicate imports.** Each collection property appended `import com.bradyaiello.deepprint.deepPrintContents` to the generated file, so `WithPrimitiveArrays` got eight copies of it. Imports are gathered in a `LinkedHashSet` now.

## What is still not supported

Worth being explicit, since "more collection types" invites the question. The README's *Current Limitations* now lists these rather than saying "not all collection types are supported yet":

- `Collection`, `Iterable`, `Sequence`, `Pair`, `Triple` — fall back to `toString()`
- nested collections, eg. `List<List<Int>>` — the outer prints correctly, the inner prints as `[0, 1]`, which is not valid Kotlin
- `UByteArray`, `UShortArray`, `UIntArray`, `ULongArray`
- a property typed as a `typealias` for an annotated `data class` — the alias isn't resolved
- nullable properties, eg. `val items: List<Int>?`, generate code that doesn't compile. Not collection-specific: `val name: String?` fails the same way.

## Tests

Eight new cases in both `test-project` and `test-project-multiplatform`: int set, int mutable set, set of annotated data classes, mutable set of annotated data classes, empty set of annotated data classes, all eight primitive arrays in one class, all five JDK collection types in one class, and the typealias fallback.

25/25 pass in `test-project` and in `test-project-multiplatform` on `jvmTest`, `jsNodeTest` and `macosArm64Test`. Reflection's 20 still pass and `detekt` is clean.

`linkDebugTestIosSimulatorArm64` fails on this branch with `ld: unknown options: -ios_simulator_version_min` — that is Kotlin/Native 1.8.21 against a current Xcode, it reproduces on unmodified `main`, and #26 fixes it.

## CI

Rebased onto `main` now that #26 has landed, so this runs on Gradle 9.7.1 / Kotlin 2.4.10 / KSP 2.

Verified locally on the rebased branch, from a clean build directory: `test-project` 25/25, and `test-project-multiplatform` 25/25 on `jvmTest`, `jsNodeTest`, `macosArm64Test` and `watchosSimulatorArm64Test`. Reflection's 20 still pass and `detekt` is clean.

## Relationship to #26

The two overlap in `DeepPrintSymbolProcessor.kt` — #26 edits `process()`, this edits the visitor below it — and the rebase was clean, with both sets of changes intact.

#28 is independent of this one; they touch different modules.


