### PR TITLE
Reflection: support Set, MutableSet and the primitive arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,31 @@ you know the type, and may want to reflect that.
 For this reason, there are functions for both mutable and immutable variants,
 eg. `deepPrintListReflection()` and `deepPrintMutableListReflection()`.
 
+The same applies to `Set`: a property declared `Set<T>` or `MutableSet<T>` prints as
+`mutableSetOf()`, while standalone there are `deepPrintSetReflection()` and
+`deepPrintMutableSetReflection()`.
+
+These are the collection types reflection handles:
+
+| Property type | Printed as | Standalone function |
+| --- | --- | --- |
+| `List<T>`, `MutableList<T>` | `mutableListOf(...)` | `deepPrintListReflection()`, `deepPrintMutableListReflection()` |
+| `Set<T>`, `MutableSet<T>` | `mutableSetOf(...)` | `deepPrintSetReflection()`, `deepPrintMutableSetReflection()` |
+| `Map<K, V>`, `MutableMap<K, V>` | `mutableMapOf(...)` | `deepPrintMapReflection()`, `deepPrintMutableMapReflection()` |
+| `Array<T>` | `arrayOf(...)` | `deepPrintArrayReflection()` |
+| `ByteArray` | `byteArrayOf(...)` | `deepPrintByteArrayReflection()` |
+| `ShortArray` | `shortArrayOf(...)` | `deepPrintShortArrayReflection()` |
+| `IntArray` | `intArrayOf(...)` | `deepPrintIntArrayReflection()` |
+| `LongArray` | `longArrayOf(...)` | `deepPrintLongArrayReflection()` |
+| `FloatArray` | `floatArrayOf(...)` | `deepPrintFloatArrayReflection()` |
+| `DoubleArray` | `doubleArrayOf(...)` | `deepPrintDoubleArrayReflection()` |
+| `BooleanArray` | `booleanArrayOf(...)` | `deepPrintBooleanArrayReflection()` |
+| `CharArray` | `charArrayOf(...)` | `deepPrintCharArrayReflection()` |
+
+The primitive arrays need no mutable/read-only distinction, so each has a single
+function. Their element type is known from the array type itself, so unlike
+`List` and `Set` there is nothing lost to erasure.
+
 ## KSP Simple Example
 For a simple example, we'll use a small class `SampleClass`:
 ```kotlin

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectPrimitiveArray.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectPrimitiveArray.kt
@@ -1,0 +1,225 @@
+@file:Suppress("TooManyFunctions")
+
+package com.bradyaiello.deepprint
+
+/*
+ * ByteArray, IntArray and the rest have no common supertype and are not Array<T>,
+ * so each one needs its own entry points. They all hold primitives, so the contents
+ * never need to recurse the way a List or an Array of data classes does.
+ *
+ * Eight types times two entry points each is what puts this file over detekt's
+ * TooManyFunctions threshold; there is no shorter way to cover them.
+ */
+
+fun ByteArray.deepPrintByteArrayReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "byteArrayOf",
+        standalone = true,
+    )
+): String = asIterable().deepPrintPrimitiveItems(deepPrintReflectConfig)
+
+fun ByteArray.deepPrintByteArrayReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "byteArrayOf",
+    standalone: Boolean = true,
+): String = asIterable().deepPrintPrimitiveItems(
+    DeepPrintReflectConfig(
+        startingIndent = startingIndent,
+        indentSize = indentSize,
+        constructor = constructor,
+        standalone = standalone,
+    )
+)
+
+fun ShortArray.deepPrintShortArrayReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "shortArrayOf",
+        standalone = true,
+    )
+): String = asIterable().deepPrintPrimitiveItems(deepPrintReflectConfig)
+
+fun ShortArray.deepPrintShortArrayReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "shortArrayOf",
+    standalone: Boolean = true,
+): String = asIterable().deepPrintPrimitiveItems(
+    DeepPrintReflectConfig(
+        startingIndent = startingIndent,
+        indentSize = indentSize,
+        constructor = constructor,
+        standalone = standalone,
+    )
+)
+
+fun IntArray.deepPrintIntArrayReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "intArrayOf",
+        standalone = true,
+    )
+): String = asIterable().deepPrintPrimitiveItems(deepPrintReflectConfig)
+
+fun IntArray.deepPrintIntArrayReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "intArrayOf",
+    standalone: Boolean = true,
+): String = asIterable().deepPrintPrimitiveItems(
+    DeepPrintReflectConfig(
+        startingIndent = startingIndent,
+        indentSize = indentSize,
+        constructor = constructor,
+        standalone = standalone,
+    )
+)
+
+fun LongArray.deepPrintLongArrayReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "longArrayOf",
+        standalone = true,
+    )
+): String = asIterable().deepPrintPrimitiveItems(deepPrintReflectConfig)
+
+fun LongArray.deepPrintLongArrayReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "longArrayOf",
+    standalone: Boolean = true,
+): String = asIterable().deepPrintPrimitiveItems(
+    DeepPrintReflectConfig(
+        startingIndent = startingIndent,
+        indentSize = indentSize,
+        constructor = constructor,
+        standalone = standalone,
+    )
+)
+
+fun FloatArray.deepPrintFloatArrayReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "floatArrayOf",
+        standalone = true,
+    )
+): String = asIterable().deepPrintPrimitiveItems(deepPrintReflectConfig)
+
+fun FloatArray.deepPrintFloatArrayReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "floatArrayOf",
+    standalone: Boolean = true,
+): String = asIterable().deepPrintPrimitiveItems(
+    DeepPrintReflectConfig(
+        startingIndent = startingIndent,
+        indentSize = indentSize,
+        constructor = constructor,
+        standalone = standalone,
+    )
+)
+
+fun DoubleArray.deepPrintDoubleArrayReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "doubleArrayOf",
+        standalone = true,
+    )
+): String = asIterable().deepPrintPrimitiveItems(deepPrintReflectConfig)
+
+fun DoubleArray.deepPrintDoubleArrayReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "doubleArrayOf",
+    standalone: Boolean = true,
+): String = asIterable().deepPrintPrimitiveItems(
+    DeepPrintReflectConfig(
+        startingIndent = startingIndent,
+        indentSize = indentSize,
+        constructor = constructor,
+        standalone = standalone,
+    )
+)
+
+fun BooleanArray.deepPrintBooleanArrayReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "booleanArrayOf",
+        standalone = true,
+    )
+): String = asIterable().deepPrintPrimitiveItems(deepPrintReflectConfig)
+
+fun BooleanArray.deepPrintBooleanArrayReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "booleanArrayOf",
+    standalone: Boolean = true,
+): String = asIterable().deepPrintPrimitiveItems(
+    DeepPrintReflectConfig(
+        startingIndent = startingIndent,
+        indentSize = indentSize,
+        constructor = constructor,
+        standalone = standalone,
+    )
+)
+
+fun CharArray.deepPrintCharArrayReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "charArrayOf",
+        standalone = true,
+    )
+): String = asIterable().deepPrintPrimitiveItems(deepPrintReflectConfig)
+
+fun CharArray.deepPrintCharArrayReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "charArrayOf",
+    standalone: Boolean = true,
+): String = asIterable().deepPrintPrimitiveItems(
+    DeepPrintReflectConfig(
+        startingIndent = startingIndent,
+        indentSize = indentSize,
+        constructor = constructor,
+        standalone = standalone,
+    )
+)
+
+/**
+ * Prints [this] as a primitive array literal, or returns null if it is not one of the
+ * eight primitive array types. Used to render a `data class` property, where the only
+ * thing known about the value is that it is [Any].
+ */
+internal fun Any.deepPrintPrimitiveArrayReflectionOrNull(
+    startingIndent: Int,
+    indentSize: Int,
+): String? {
+    val (items, constructor) = when (this) {
+        is ByteArray -> asIterable() to "byteArrayOf"
+        is ShortArray -> asIterable() to "shortArrayOf"
+        is IntArray -> asIterable() to "intArrayOf"
+        is LongArray -> asIterable() to "longArrayOf"
+        is FloatArray -> asIterable() to "floatArrayOf"
+        is DoubleArray -> asIterable() to "doubleArrayOf"
+        is BooleanArray -> asIterable() to "booleanArrayOf"
+        is CharArray -> asIterable() to "charArrayOf"
+        else -> return null
+    }
+    return items.deepPrintPrimitiveItems(
+        DeepPrintReflectConfig(
+            startingIndent = startingIndent,
+            indentSize = indentSize,
+            constructor = constructor,
+            standalone = false,
+        )
+    )
+}
+
+private fun Iterable<Any?>.deepPrintPrimitiveItems(
+    deepPrintReflectConfig: DeepPrintReflectConfig,
+): String = with(deepPrintReflectConfig) {
+    val stringBuilder = StringBuilder()
+    val start = startingIndent.indent()
+    val prefix = if (standalone) start else " "
+    stringBuilder.append("$prefix$constructor(\n")
+    val itemIndent = start + indentSize.indent()
+    forEach { value ->
+        stringBuilder.append("$itemIndent${deepPrintPrimitive(value)},\n")
+    }
+    stringBuilder.append("$start)")
+    stringBuilder.toString()
+}

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectSet.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectSet.kt
@@ -1,0 +1,64 @@
+package com.bradyaiello.deepprint
+
+fun <T> Set<T>.deepPrintSetReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "setOf",
+        standalone = true,
+    )
+): String {
+    return with(deepPrintReflectConfig) {
+        deepPrintSetReflection(
+            startingIndent = startingIndent,
+            indentSize = indentSize,
+            constructor = constructor,
+            standalone = standalone,
+        )
+    }
+}
+
+fun <T> Set<T>.deepPrintSetReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "setOf",
+    standalone: Boolean = true,
+): String {
+    val stringBuilder = StringBuilder()
+    val start = startingIndent.indent()
+    val prefix = if (standalone) start else " "
+    stringBuilder.append("${prefix}$constructor(\n")
+    this.forEach { value ->
+        value.deepPrintListItem(stringBuilder, startingIndent, indentSize)
+    }
+    stringBuilder.append("${start})")
+    return stringBuilder.toString()
+}
+
+fun <T> MutableSet<T>.deepPrintMutableSetReflection(
+    deepPrintReflectConfig: DeepPrintReflectConfig = DeepPrintReflectConfig(
+        constructor = "mutableSetOf",
+        standalone = true,
+    )
+): String {
+    return with(deepPrintReflectConfig) {
+        deepPrintMutableSetReflection(
+            startingIndent = startingIndent,
+            indentSize = indentSize,
+            constructor = constructor,
+            standalone = standalone,
+        )
+    }
+}
+
+fun <T> MutableSet<T>.deepPrintMutableSetReflection(
+    startingIndent: Int = 0,
+    indentSize: Int = 4,
+    constructor: String = "mutableSetOf",
+    standalone: Boolean = true,
+): String {
+    return this.deepPrintSetReflection(
+        startingIndent = startingIndent,
+        indentSize = indentSize,
+        constructor = constructor,
+        standalone = standalone,
+    )
+}

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
@@ -4,6 +4,14 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.memberProperties
 
+/*
+    List and MutableList look identical at runtime. They both are implemented by
+    Java ArrayList, and the same goes for Set and MutableSet, and for Map and
+    MutableMap. So we must default to the mutable constructor, which produces valid
+    code for both the read-only and the mutable declaration.
+    https://youtrack.jetbrains.com/issue/KT-23652/Reflection-Classifier-for-MutableListT-same-as-for-ListT
+    https://youtrack.jetbrains.com/issue/KT-11754/Support-special-KClass-instances-for-mutable-collection-interfaces
+ */
 fun Any?.deepPrintReflection(
     initialIndentLength: Int = 0,
     indentIncrementLength: Int = 4,
@@ -14,65 +22,64 @@ fun Any?.deepPrintReflection(
     val kClass = this::class
     val initialIndent = if (initialIndentLength == 0) ""
     else initialIndentLength.indent()
-    val indentIncrement = indentIncrementLength.indent()
     val builder = StringBuilder()
     val constructor = kClass.constructors.first()
     val constructorCall = "${kClass.simpleName!!}(\n"
     builder.append("$initialIndent$constructorCall")
     val params = constructor.parameters
-    val startingIndentForParams = initialIndentLength + indentIncrementLength
-    val listConfig = DeepPrintReflectConfig(startingIndent = startingIndentForParams, constructor = "mutableListOf")
-    val mapConfig = DeepPrintReflectConfig(startingIndent = startingIndentForParams, constructor = "mutableMapOf")
-    val arrayConfig = DeepPrintReflectConfig(startingIndent = startingIndentForParams, constructor = "arrayOf")
-    
+
     params.forEach { kParam ->
-        val propName = kParam.name
-        val propValue = this.getPropertyValue(kParam)!!
-        if (propValue::class.isPrimitive()) {
-            builder.append("$initialIndent$indentIncrement$propName = ${deepPrintPrimitive(propValue)},\n")
-        } else if (propValue is List<*>) {
-            /*
-                List and MutableList look identical at runtime. 
-                They both are implemented by Java Arraylist.
-                So we must default to using the constructor for mutableListOf(),
-                which works for List and MutableList.
-                https://youtrack.jetbrains.com/issue/KT-23652/Reflection-Classifier-for-MutableListT-same-as-for-ListT
-                https://youtrack.jetbrains.com/issue/KT-11754/Support-special-KClass-instances-for-mutable-collection-interfaces
-             */
-            builder.append(
-                "$initialIndent$indentIncrement$propName = ${
-                    propValue.deepPrintListReflection(listConfig)
-                },\n"
+        builder.append(
+            deepPrintProperty(
+                propName = kParam.name,
+                propValue = this.getPropertyValue(kParam)!!,
+                initialIndentLength = initialIndentLength,
+                indentIncrementLength = indentIncrementLength,
             )
-        } else if (propValue is Map<*,*>) {
-            builder.append(
-                "$initialIndent$indentIncrement$propName = ${
-                    propValue.deepPrintMapReflection(mapConfig)
-                },\n"
-            )
-        } else if (propValue is Array<*>) {
-            builder.append(
-                "$initialIndent$indentIncrement$propName = ${
-                    propValue.deepPrintArrayReflection(arrayConfig)
-                },\n"
-            )
-        }
-        
-        else {
-            builder.append(
-                propValue.deepPrintReflection(
-                    initialIndentLength = initialIndentLength + indentIncrementLength,
-                    indentIncrementLength = indentIncrementLength,
-                )
-            )
-            builder.append("\n")
-        }
+        )
     }
     builder.append("$initialIndent)")
     if (initialIndentLength != 0) {
         builder.append(",")
     }
     return builder.toString()
+}
+
+@Suppress("ReturnCount")
+private fun deepPrintProperty(
+    propName: String?,
+    propValue: Any,
+    initialIndentLength: Int,
+    indentIncrementLength: Int,
+): String {
+    val assignment = "${initialIndentLength.indent()}${indentIncrementLength.indent()}$propName = "
+    val startingIndent = initialIndentLength + indentIncrementLength
+    fun config(constructor: String) = DeepPrintReflectConfig(
+        startingIndent = startingIndent,
+        indentSize = indentIncrementLength,
+        constructor = constructor,
+    )
+
+    if (propValue::class.isPrimitive()) {
+        return "$assignment${deepPrintPrimitive(propValue)},\n"
+    }
+    when (propValue) {
+        is List<*> -> return "$assignment${propValue.deepPrintListReflection(config("mutableListOf"))},\n"
+        is Set<*> -> return "$assignment${propValue.deepPrintSetReflection(config("mutableSetOf"))},\n"
+        is Map<*, *> -> return "$assignment${propValue.deepPrintMapReflection(config("mutableMapOf"))},\n"
+        is Array<*> -> return "$assignment${propValue.deepPrintArrayReflection(config("arrayOf"))},\n"
+    }
+    val primitiveArray = propValue.deepPrintPrimitiveArrayReflectionOrNull(
+        startingIndent = startingIndent,
+        indentSize = indentIncrementLength,
+    )
+    if (primitiveArray != null) {
+        return "$assignment$primitiveArray,\n"
+    }
+    return propValue.deepPrintReflection(
+        initialIndentLength = startingIndent,
+        indentIncrementLength = indentIncrementLength,
+    ) + "\n"
 }
 
 private fun Any.getPropertyValue(kParam: KParameter): Any? {

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectCollectionsTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectCollectionsTest.kt
@@ -1,0 +1,231 @@
+package com.bradyaiello.deepprint
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Sets and the primitive arrays. The older collection types are covered in
+ * [ReflectionTest].
+ */
+class ReflectCollectionsTest {
+
+    @Test
+    fun `deep print set of Integers`() {
+        val mySet = setOf(1, 2, 3, 4, 5)
+        val expected = """
+            setOf(
+                1,
+                2,
+                3,
+                4,
+                5,
+            )
+        """.trimIndent()
+        val actual = mySet.deepPrintSetReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print mutable set of Integers`() {
+        val mySet = mutableSetOf(1, 2, 3, 4, 5)
+        val expected = """
+            mutableSetOf(
+                1,
+                2,
+                3,
+                4,
+                5,
+            )
+        """.trimIndent()
+        val actual = mySet.deepPrintMutableSetReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print standalone Set of data classes`() {
+        val mySet = createPeople().toSet()
+        val expected = """
+            setOf(
+                Person(
+                    name = "Brady",
+                    age = 38,
+                    Address(
+                        streetAddress = "414 Koshland Way",
+                        city = "Santa Cruz",
+                        state = "CA",
+                        zipCode = "95064",
+                    ),
+                ),
+                Person(
+                    name = "Joe",
+                    age = 80,
+                    Address(
+                        streetAddress = "1600 Pennsylvania Avenue, N.W.",
+                        city = "Washington",
+                        state = "DC",
+                        zipCode = "20500",
+                    ),
+                ),
+            )
+        """.trimIndent()
+        val actual = mySet.deepPrintSetReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print data class with a set of Integers`() {
+        val setContainer = SetContainer(
+            someString = "Some String",
+            numbers = setOf(1, 2, 3, 4, 5)
+        )
+        // Set and MutableSet are the same class at runtime, so mutableSetOf() is
+        // printed: it is the constructor that is valid for both.
+        val expected = """
+            SetContainer(
+                someString = "Some String",
+                numbers =  mutableSetOf(
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                ),
+            )
+        """.trimIndent()
+        val actual = setContainer.deepPrintReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print data class with a set of data classes`() {
+        val withSetOfDataClasses = WithSetOfDataClasses(
+            id = "12345",
+            people = createPeople().toSet()
+        )
+        val expected = """
+            WithSetOfDataClasses(
+                id = "12345",
+                people =  mutableSetOf(
+                    Person(
+                        name = "Brady",
+                        age = 38,
+                        Address(
+                            streetAddress = "414 Koshland Way",
+                            city = "Santa Cruz",
+                            state = "CA",
+                            zipCode = "95064",
+                        ),
+                    ),
+                    Person(
+                        name = "Joe",
+                        age = 80,
+                        Address(
+                            streetAddress = "1600 Pennsylvania Avenue, N.W.",
+                            city = "Washington",
+                            state = "DC",
+                            zipCode = "20500",
+                        ),
+                    ),
+                ),
+            )
+        """.trimIndent()
+        val actual = withSetOfDataClasses.deepPrintReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print standalone IntArray`() {
+        val myArray = intArrayOf(1, 2, 3, 4, 5)
+        val expected = """
+            intArrayOf(
+                1,
+                2,
+                3,
+                4,
+                5,
+            )
+        """.trimIndent()
+        val actual = myArray.deepPrintIntArrayReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print standalone FloatArray`() {
+        val myArray = floatArrayOf(1f, 2.5f)
+        val expected = """
+            floatArrayOf(
+                1.0f,
+                2.5f,
+            )
+        """.trimIndent()
+        val actual = myArray.deepPrintFloatArrayReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print standalone CharArray`() {
+        val myArray = charArrayOf('A', 'B')
+        val expected = """
+            charArrayOf(
+                'A',
+                'B',
+            )
+        """.trimIndent()
+        val actual = myArray.deepPrintCharArrayReflection()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deep print data class with primitive arrays`() {
+        val primitiveArraysContainer = PrimitiveArraysContainer(
+            bytes = byteArrayOf(-1, 0, 1),
+            shorts = shortArrayOf(2, 3),
+            ints = intArrayOf(1, 2, 3),
+            longs = longArrayOf(1000L, 2000L),
+            floats = floatArrayOf(26.2f, 1f),
+            doubles = doubleArrayOf(26.2, 1.0),
+            booleans = booleanArrayOf(true, false),
+            chars = charArrayOf('a', 'b'),
+        )
+        val expected = """
+            PrimitiveArraysContainer(
+                bytes =  byteArrayOf(
+                    -1,
+                    0,
+                    1,
+                ),
+                shorts =  shortArrayOf(
+                    2,
+                    3,
+                ),
+                ints =  intArrayOf(
+                    1,
+                    2,
+                    3,
+                ),
+                longs =  longArrayOf(
+                    1000,
+                    2000,
+                ),
+                floats =  floatArrayOf(
+                    26.2f,
+                    1.0f,
+                ),
+                doubles =  doubleArrayOf(
+                    26.2,
+                    1.0,
+                ),
+                booleans =  booleanArrayOf(
+                    true,
+                    false,
+                ),
+                chars =  charArrayOf(
+                    'a',
+                    'b',
+                ),
+            )
+        """.trimIndent()
+        val actual = primitiveArraysContainer.deepPrintReflection()
+        assertEquals(expected, actual)
+    }
+}

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
@@ -548,29 +548,7 @@ class ReflectionTest {
         assertEquals(expected, actual)
     }
     
-    private fun createMutableListOfPeople(): MutableList<Person> {
-        val brady = Person(
-            name = "Brady",
-            age = 38,
-            Address(
-                streetAddress = "414 Koshland Way",
-                city = "Santa Cruz",
-                state = "CA",
-                zipCode = "95064"
-            )
-        )
-        val prez = Person(
-            name = "Joe",
-            age = 80,
-            Address(
-                streetAddress = "1600 Pennsylvania Avenue, N.W.",
-                city = "Washington",
-                state = "DC",
-                zipCode = "20500"
-            )
-        )
-        return mutableListOf(brady, prez)
-    }
+    private fun createMutableListOfPeople(): MutableList<Person> = createPeople()
     
     private fun createWithListOfDataClasses(
         someListContainer: ListContainer

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
@@ -51,3 +51,48 @@ data class ArrayHolder(
     val numbers: Array<Int>,
     val primitiveContainers: Array<PrimitivesContainer>
 )
+
+data class SetContainer(
+    val someString: String,
+    val numbers: Set<Int>
+)
+
+data class WithSetOfDataClasses(
+    val id: String,
+    val people: Set<Person>
+)
+
+data class PrimitiveArraysContainer(
+    val bytes: ByteArray,
+    val shorts: ShortArray,
+    val ints: IntArray,
+    val longs: LongArray,
+    val floats: FloatArray,
+    val doubles: DoubleArray,
+    val booleans: BooleanArray,
+    val chars: CharArray,
+)
+
+internal fun createPeople(): MutableList<Person> {
+    val brady = Person(
+        name = "Brady",
+        age = 38,
+        Address(
+            streetAddress = "414 Koshland Way",
+            city = "Santa Cruz",
+            state = "CA",
+            zipCode = "95064"
+        )
+    )
+    val prez = Person(
+        name = "Joe",
+        age = 80,
+        Address(
+            streetAddress = "1600 Pennsylvania Avenue, N.W.",
+            city = "Washington",
+            state = "DC",
+            zipCode = "20500"
+        )
+    )
+    return mutableListOf(brady, prez)
+}


### PR DESCRIPTION
Adds the collection types the reflection implementation was missing.

| Property type | Printed as | Standalone function |
| --- | --- | --- |
| `Set<T>`, `MutableSet<T>` | `mutableSetOf(...)` | `deepPrintSetReflection()`, `deepPrintMutableSetReflection()` |
| `ByteArray` | `byteArrayOf(...)` | `deepPrintByteArrayReflection()` |
| `ShortArray` | `shortArrayOf(...)` | `deepPrintShortArrayReflection()` |
| `IntArray` | `intArrayOf(...)` | `deepPrintIntArrayReflection()` |
| `LongArray` | `longArrayOf(...)` | `deepPrintLongArrayReflection()` |
| `FloatArray` | `floatArrayOf(...)` | `deepPrintFloatArrayReflection()` |
| `DoubleArray` | `doubleArrayOf(...)` | `deepPrintDoubleArrayReflection()` |
| `BooleanArray` | `booleanArrayOf(...)` | `deepPrintBooleanArrayReflection()` |
| `CharArray` | `charArrayOf(...)` | `deepPrintCharArrayReflection()` |

**Sets** follow the existing List design exactly. `Set` and `MutableSet` are the same class at runtime, so a `data class` property prints as `mutableSetOf()` — the constructor that produces valid code for either declaration. Standalone you know the type, so both variants exist.

**Primitive arrays** are not `Array<T>` and share no supertype, so each needs its own entry points. They only ever hold primitives, so their contents never recurse the way an `Array<Person>` does.

## Refactor, and one behaviour change

`deepPrintReflection()` went past detekt's `LongMethod` threshold once two more branches went in, so the per-property rendering moved out into `deepPrintProperty()`.

One behaviour change falls out of that, and it's worth a look: the collection configs now pass `indentIncrementLength` through as the indent size. They previously left it at the default of 4, so `deepPrintReflection(indentIncrementLength = 2)` gave you a 2-space indented data class with 4-space indented collections inside it. Every existing test uses the default of 4, so nothing in the suite moved.

## Tests

Nine new cases, in a new `ReflectCollectionsTest` rather than `ReflectionTest` — detekt already considered that class a `LargeClass`, and it would have tipped over. The people fixture the two share moved to `TestClasses.kt`.

- standalone `setOf` / `mutableSetOf` of ints
- standalone set of data classes
- `data class` with a `Set<Int>` and with a `Set<Person>`
- standalone `IntArray`, `FloatArray`, `CharArray`
- `data class` holding all eight primitive arrays

29 pass, and `:deep-print-reflection:check` (tests + detekt) is clean.

## Note on ordering

Rebased onto `main` now that #26 has landed, so it runs on Gradle 9.7.1 / Kotlin 2.4.10. It only touches `deep-print-reflection/**` and the README, so it does not overlap with #27.
