### PR TITLE
Reflection: stop dropping properties, stop throwing on null, name nested properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,24 @@ The primitive arrays need no mutable/read-only distinction, so each has a single
 function. Their element type is known from the array type itself, so unlike
 `List` and `Set` there is nothing lost to erasure.
 
+### Reflection and Values It Cannot Reconstruct
+
+A `null` property prints as `null`. An enum prints qualified, so
+`day = DayOfWeek.MONDAY` is valid Kotlin once the enum is imported.
+
+Anything else that is neither a primitive, a supported collection, nor a `data class`
+falls back to `toString()`:
+
+```kotlin
+OpaqueContainer(
+    id = Opaque(abc),
+    name = "x",
+)
+```
+
+That line is not something you can paste back into a test, but the property is at
+least present and says what it held.
+
 ## KSP Simple Example
 For a simple example, we'll use a small class `SampleClass`:
 ```kotlin
@@ -403,15 +421,19 @@ That is not true for single source projects, like [test-project](./test-project)
   - `Collection`, `Iterable` and `Sequence` properties, and `Pair` and `Triple`.
     These fall back to `toString()`, so the output is readable but is not a
     constructor call.
-  - Nested collections, eg. `List<List<Int>>` or `Map<String, List<Int>>` with a
-    collection value. The outer collection prints correctly, but the inner one prints
-    via `toString()` as `[0, 1]`, which is not valid Kotlin.
+  - Nested collections, eg. `List<List<Int>>`. The outer collection prints correctly,
+    but the inner one prints via `toString()` as `[0, 1]`, which is not valid Kotlin.
+    For KSP, `Map<String, List<Int>>` is worse: it generates code that does not compile.
   - The unsigned arrays `UByteArray`, `UShortArray`, `UIntArray` and `ULongArray`.
   - A property whose type is a `typealias` for a `@DeepPrint` `data class`. The alias
     is not resolved, so the property falls back to `toString()`.
-- Nullable properties are not supported. A `val items: List<Int>?` generates code that
-  does not compile. This is not specific to collections: `val name: String?` has the
-  same problem.
+- For KSP, nullable properties are not supported. A `val items: List<Int>?` generates
+  code that does not compile. This is not specific to collections: `val name: String?`
+  has the same problem. Reflection handles nullable properties and prints `null`.
+- For reflection, a property that is neither a primitive, a supported collection, nor a
+  `data class` is printed with `toString()`. Enums are the exception and print
+  qualified, eg. `day = DayOfWeek.MONDAY`, which is valid Kotlin as long as the enum is
+  imported.
 - On Kotlin/JS, `Float`, `Double` and `Char` elements of a `List`, `Set` or `Array` are
   identified by their runtime type, which JS erases to a number. `2.0f` prints as `2` and
   `'A'` prints as `65`. `FloatArray`, `DoubleArray` and `CharArray` are not affected, and

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectList.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectList.kt
@@ -72,8 +72,10 @@ internal fun <Any> Any?.deepPrintListItem(
 
     if (this == null) {
         stringBuilder.append("${totalIndent}null,\n")
-    } else if (this!!::class.isPrimitive()) {
+    } else if (this::class.isPrimitive()) {
         stringBuilder.append("${totalIndent}${deepPrintPrimitive(this)},\n")
+    } else if (!this::class.isData) {
+        stringBuilder.append("${totalIndent}${this.deepPrintUnsupportedReflection()},\n")
     } else {
         stringBuilder.append(
             this.deepPrintReflection(

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectMap.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectMap.kt
@@ -78,8 +78,10 @@ private fun <Any> Any?.deepPrintMapKeyOrValue(
 
     if (this == null) {
         stringBuilder.append("${totalIndent}null")
-    } else if (this!!::class.isPrimitive()) {
+    } else if (this::class.isPrimitive()) {
         stringBuilder.append("${totalIndent}${deepPrintPrimitive(this)}")
+    } else if (!this::class.isData) {
+        stringBuilder.append("${totalIndent}${this.deepPrintUnsupportedReflection()}")
     } else {
         stringBuilder.append(
             this.deepPrintReflection(
@@ -100,7 +102,7 @@ private fun <K, V> Map.Entry<K, V?>.deepPrintMapEntryReflection(
         startingIndent = startingIndent,
         indentSize = indentSize
     )
-    val singleLine = key!!.isPrimitive() && ((value == null) || value!!.isPrimitive())
+    val singleLine = key.printsInline() && value.printsInline()
     val toStr = if (singleLine) " to " else " to\n"
     stringBuilder.append(toStr)
     val newStartingIndent = if (singleLine) 0 else startingIndent + indentSize

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectPrimitiveArray.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectPrimitiveArray.kt
@@ -179,6 +179,12 @@ fun CharArray.deepPrintCharArrayReflection(
     )
 )
 
+internal fun Any.isPrimitiveArray(): Boolean = when (this) {
+    is ByteArray, is ShortArray, is IntArray, is LongArray,
+    is FloatArray, is DoubleArray, is BooleanArray, is CharArray -> true
+    else -> false
+}
+
 /**
  * Prints [this] as a primitive array literal, or returns null if it is not one of the
  * eight primitive array types. Used to render a `data class` property, where the only

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
@@ -32,7 +32,7 @@ fun Any?.deepPrintReflection(
         builder.append(
             deepPrintProperty(
                 propName = kParam.name,
-                propValue = this.getPropertyValue(kParam)!!,
+                propValue = this.getPropertyValue(kParam),
                 initialIndentLength = initialIndentLength,
                 indentIncrementLength = indentIncrementLength,
             )
@@ -48,7 +48,7 @@ fun Any?.deepPrintReflection(
 @Suppress("ReturnCount")
 private fun deepPrintProperty(
     propName: String?,
-    propValue: Any,
+    propValue: Any?,
     initialIndentLength: Int,
     indentIncrementLength: Int,
 ): String {
@@ -60,6 +60,9 @@ private fun deepPrintProperty(
         constructor = constructor,
     )
 
+    if (propValue == null) {
+        return "${assignment}null,\n"
+    }
     if (propValue::class.isPrimitive()) {
         return "$assignment${deepPrintPrimitive(propValue)},\n"
     }
@@ -76,10 +79,46 @@ private fun deepPrintProperty(
     if (primitiveArray != null) {
         return "$assignment$primitiveArray,\n"
     }
-    return propValue.deepPrintReflection(
+    if (!propValue::class.isData) {
+        return "$assignment${propValue.deepPrintUnsupportedReflection()},\n"
+    }
+    // deepPrintReflection() indents the constructor call itself, but the name and the
+    // `=` are already on the line, so that leading indent has to come back off.
+    val nested = propValue.deepPrintReflection(
         initialIndentLength = startingIndent,
         indentIncrementLength = indentIncrementLength,
-    ) + "\n"
+    )
+    return assignment + nested.removePrefix(startingIndent.indent()) + "\n"
+}
+
+/**
+ * Last resort for a value that is neither a primitive, a supported collection, nor a
+ * `data class`: an enum, a java.time value, a UUID. There is nothing to recurse into,
+ * but dropping the property would produce output that looks complete and is not, so
+ * print what the value knows how to say about itself.
+ *
+ * Only enums come back out as valid Kotlin. Everything else is a readable placeholder
+ * that has to be filled in by hand.
+ */
+/**
+ * True when the value occupies a single line: primitives, enums, and anything else
+ * that falls back to toString(). Collections and nested `data class`es open a block
+ * and so cannot share a line with a map key.
+ */
+internal fun Any?.printsInline(): Boolean = when {
+    this == null -> true
+    isPrimitive() -> true
+    this is Collection<*> || this is Map<*, *> || this is Array<*> || isPrimitiveArray() -> false
+    else -> !this::class.isData
+}
+
+internal fun Any.deepPrintUnsupportedReflection(): String = when (this) {
+    is Enum<*> -> {
+        // An enum constant with a body is an anonymous subclass of the enum itself.
+        val enumClass = if (javaClass.isEnum) javaClass else javaClass.superclass
+        "${enumClass.simpleName}.$name"
+    }
+    else -> toString()
 }
 
 private fun Any.getPropertyValue(kParam: KParameter): Any? {

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectCollectionsTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectCollectionsTest.kt
@@ -49,7 +49,7 @@ class ReflectCollectionsTest {
                 Person(
                     name = "Brady",
                     age = 38,
-                    Address(
+                    address = Address(
                         streetAddress = "414 Koshland Way",
                         city = "Santa Cruz",
                         state = "CA",
@@ -59,7 +59,7 @@ class ReflectCollectionsTest {
                 Person(
                     name = "Joe",
                     age = 80,
-                    Address(
+                    address = Address(
                         streetAddress = "1600 Pennsylvania Avenue, N.W.",
                         city = "Washington",
                         state = "DC",
@@ -109,7 +109,7 @@ class ReflectCollectionsTest {
                     Person(
                         name = "Brady",
                         age = 38,
-                        Address(
+                        address = Address(
                             streetAddress = "414 Koshland Way",
                             city = "Santa Cruz",
                             state = "CA",
@@ -119,7 +119,7 @@ class ReflectCollectionsTest {
                     Person(
                         name = "Joe",
                         age = 80,
-                        Address(
+                        address = Address(
                             streetAddress = "1600 Pennsylvania Avenue, N.W.",
                             city = "Washington",
                             state = "DC",

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectFallbackTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectFallbackTest.kt
@@ -1,0 +1,97 @@
+package com.bradyaiello.deepprint
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Null values, and values that are neither primitives, collections, nor `data class`es.
+ */
+class ReflectFallbackTest {
+
+    @Test
+    fun `null properties print as null`() {
+        val container = NullableContainer(
+            name = null,
+            count = null,
+            address = null,
+            numbers = null,
+        )
+        val expected = """
+            NullableContainer(
+                name = null,
+                count = null,
+                address = null,
+                numbers = null,
+            )
+        """.trimIndent()
+        assertEquals(expected, container.deepPrintReflection())
+    }
+
+    @Test
+    fun `nullable properties print normally when populated`() {
+        val container = NullableContainer(
+            name = "Brady",
+            count = 3,
+            address = Address(
+                streetAddress = "414 Koshland Way",
+                city = "Santa Cruz",
+                state = "CA",
+                zipCode = "95064"
+            ),
+            numbers = listOf(1, 2),
+        )
+        val expected = """
+            NullableContainer(
+                name = "Brady",
+                count = 3,
+                address = Address(
+                    streetAddress = "414 Koshland Way",
+                    city = "Santa Cruz",
+                    state = "CA",
+                    zipCode = "95064",
+                ),
+                numbers =  mutableListOf(
+                    1,
+                    2,
+                ),
+            )
+        """.trimIndent()
+        assertEquals(expected, container.deepPrintReflection())
+    }
+
+    @Test
+    fun `enums print qualified, as a property, a list item and a map key`() {
+        val container = EnumContainer(
+            day = DayOfWeek.MONDAY,
+            days = listOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY),
+            byDay = mapOf(DayOfWeek.MONDAY to "washing"),
+        )
+        val expected = """
+            EnumContainer(
+                day = DayOfWeek.MONDAY,
+                days =  mutableListOf(
+                    DayOfWeek.MONDAY,
+                    DayOfWeek.TUESDAY,
+                ),
+                byDay =  mutableMapOf(
+                    DayOfWeek.MONDAY to "washing",
+                ),
+            )
+        """.trimIndent()
+        assertEquals(expected, container.deepPrintReflection())
+    }
+
+    @Test
+    fun `an unsupported type falls back to toString instead of disappearing`() {
+        val container = OpaqueContainer(id = Opaque("abc"), name = "x")
+        // Not valid Kotlin, but the property is present and says what it holds. Before,
+        // it was dropped from the output entirely.
+        val expected = """
+            OpaqueContainer(
+                id = Opaque(abc),
+                name = "x",
+            )
+        """.trimIndent()
+        assertEquals(expected, container.deepPrintReflection())
+    }
+}

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectionTest.kt
@@ -30,7 +30,7 @@ class ReflectionTest {
         val brady = Person(
             name = "Brady",
             age = 38,
-            Address(
+            address = Address(
                 streetAddress = "19 Jolley Way",
                 city = "Scotts Valley",
                 state = "CA",
@@ -41,7 +41,7 @@ class ReflectionTest {
         Person(
             name = "Brady",
             age = 38,
-            Address(
+            address = Address(
                 streetAddress = "19 Jolley Way",
                 city = "Scotts Valley",
                 state = "CA",
@@ -260,7 +260,7 @@ class ReflectionTest {
                     Person(
                         name = "Brady",
                         age = 38,
-                        Address(
+                        address = Address(
                             streetAddress = "414 Koshland Way",
                             city = "Santa Cruz",
                             state = "CA",
@@ -270,7 +270,7 @@ class ReflectionTest {
                     Person(
                         name = "Joe",
                         age = 80,
-                        Address(
+                        address = Address(
                             streetAddress = "1600 Pennsylvania Avenue, N.W.",
                             city = "Washington",
                             state = "DC",
@@ -302,7 +302,7 @@ class ReflectionTest {
                     Person(
                         name = "Brady",
                         age = 38,
-                        Address(
+                        address = Address(
                             streetAddress = "414 Koshland Way",
                             city = "Santa Cruz",
                             state = "CA",
@@ -312,7 +312,7 @@ class ReflectionTest {
                     Person(
                         name = "Joe",
                         age = 80,
-                        Address(
+                        address = Address(
                             streetAddress = "1600 Pennsylvania Avenue, N.W.",
                             city = "Washington",
                             state = "DC",
@@ -320,7 +320,7 @@ class ReflectionTest {
                         ),
                     ),
                 ),
-                MutableListContainer(
+                mutableListContainer = MutableListContainer(
                     someString = "Some String",
                     numbers =  mutableListOf(
                         1,
@@ -353,7 +353,7 @@ class ReflectionTest {
                     Person(
                         name = "Brady",
                         age = 38,
-                        Address(
+                        address = Address(
                             streetAddress = "414 Koshland Way",
                             city = "Santa Cruz",
                             state = "CA",
@@ -363,7 +363,7 @@ class ReflectionTest {
                     Person(
                         name = "Joe",
                         age = 80,
-                        Address(
+                        address = Address(
                             streetAddress = "1600 Pennsylvania Avenue, N.W.",
                             city = "Washington",
                             state = "DC",
@@ -371,7 +371,7 @@ class ReflectionTest {
                         ),
                     ),
                 ),
-                ListContainer(
+                listContainer = ListContainer(
                     someString = "Some String",
                     numbers =  mutableListOf(
                         1,
@@ -432,7 +432,7 @@ class ReflectionTest {
                     Person(
                         name = "Brady",
                         age = 38,
-                        Address(
+                        address = Address(
                             streetAddress = "414 Koshland Way",
                             city = "Santa Cruz",
                             state = "CA",
@@ -443,7 +443,7 @@ class ReflectionTest {
                     Person(
                         name = "Joe",
                         age = 80,
-                        Address(
+                        address = Address(
                             streetAddress = "1600 Pennsylvania Avenue, N.W.",
                             city = "Washington",
                             state = "DC",

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
@@ -96,3 +96,28 @@ internal fun createPeople(): MutableList<Person> {
     )
     return mutableListOf(brady, prez)
 }
+
+enum class DayOfWeek { MONDAY, TUESDAY }
+
+/** Neither a primitive, a collection, nor a `data class`. */
+class Opaque(private val label: String) {
+    override fun toString(): String = "Opaque($label)"
+}
+
+data class NullableContainer(
+    val name: String?,
+    val count: Int?,
+    val address: Address?,
+    val numbers: List<Int>?,
+)
+
+data class EnumContainer(
+    val day: DayOfWeek,
+    val days: List<DayOfWeek>,
+    val byDay: Map<DayOfWeek, String>,
+)
+
+data class OpaqueContainer(
+    val id: Opaque,
+    val name: String,
+)


### PR DESCRIPTION
Three defects in the reflection implementation, all producing output that was wrong rather than merely incomplete.

## 1. Properties were silently dropped

`deepPrintReflection()` returns `""` for anything that isn't a `data class`, and that empty string was appended as the property's rendering. So:

```kotlin
data class PlainHolder(val id: UUID, val name: String)
```

printed as

```kotlin
PlainHolder(
    name = "x",
)
```

No error, no placeholder — `id` simply wasn't there. Enums went the same way, and so did list items and map keys/values, by the same mechanism.

Such a value now falls back to `toString()`. Enums are special-cased to print qualified — `day = DayOfWeek.MONDAY` — which is valid Kotlin once the enum is imported. Everything else gives you `id = Opaque(abc)`: not paste-able, but present and honest about what it held.

## 2. Null threw

A nullable property holding `null` threw `NullPointerException`, from the `!!` in `getPropertyValue()`. It prints `null` now.

## 3. Nested data class properties had no name

```kotlin
Person(
    name = "Brady",
    age = 38,
    Address(          // <- no `address = `
        ...
    ),
)
```

A positional argument can't follow named ones, so that isn't valid Kotlin — which is the one thing this library promises. It prints `address = Address(` now.

**This changes published output** and rewrote 16 expected strings across the existing tests. List and map elements are genuinely positional, so they're unchanged. Worth a line in the release notes for anyone on `0.1.0-alpha10`.

## One knock-on

Map entries decided between the single-line and multi-line forms by asking whether both sides were primitives. An enum value took the multi-line branch, which doesn't emit the trailing comma — so fixing #1 would have produced invalid map output. That test is now "does this value print inline", covering primitives, enums and `toString()` fallbacks alike.

## Tests

Four new cases in a new `ReflectFallbackTest`: all-null properties, the same class populated, enums as property/list item/map key, and an unsupported type. Plus the 16 rewritten expectations.

33 pass; `:deep-print-reflection:check` (tests + detekt) is clean.

## Still open

Nested collections inside a reflection collection are no longer *dropped*, but still print via `toString()` as `[0, 1]`. That's in the follow-up, along with the KSP gaps.