### PR TITLE
KSP: support nullable properties, and collections as map values

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,33 @@ A property whose type is one of these is printed as the call that rebuilds it:
 Unlike the reflection implementation, KSP sees the declared type, so a `Set` prints
 as `setOf()` and a `MutableSet` prints as `mutableSetOf()`.
 
+A collection is also supported as a map value, so `Map<String, List<Int>>` prints as
+
+```kotlin
+listsByName = mapOf<String,List<Int>>(
+    "a" to listOf<Int>( 1, 2,),
+),
+```
+
+### KSP and Nullable Properties
+
+A nullable property prints as the `null` literal when it is absent, and normally when
+it is not. This works for every supported type -- primitives, collections, maps,
+primitive arrays, and annotated `data class`es:
+
+```kotlin
+@DeepPrint
+data class Maybe(val name: String?, val items: List<Int>?, val person: Person?)
+```
+
+```kotlin
+Maybe(
+    name = null,
+    items = null,
+    person = null,
+)
+```
+
 Elements may be primitives or `@DeepPrint`-annotated `data class`es. Given:
 
 ```kotlin
@@ -423,13 +450,10 @@ That is not true for single source projects, like [test-project](./test-project)
     constructor call.
   - Nested collections, eg. `List<List<Int>>`. The outer collection prints correctly,
     but the inner one prints via `toString()` as `[0, 1]`, which is not valid Kotlin.
-    For KSP, `Map<String, List<Int>>` is worse: it generates code that does not compile.
+    A collection as a *map value*, eg. `Map<String, List<Int>>`, does work.
   - The unsigned arrays `UByteArray`, `UShortArray`, `UIntArray` and `ULongArray`.
   - A property whose type is a `typealias` for a `@DeepPrint` `data class`. The alias
     is not resolved, so the property falls back to `toString()`.
-- For KSP, nullable properties are not supported. A `val items: List<Int>?` generates
-  code that does not compile. This is not specific to collections: `val name: String?`
-  has the same problem. Reflection handles nullable properties and prints `null`.
 - For reflection, a property that is neither a primitive, a supported collection, nor a
   `data class` is printed with `toString()`. Enums are the exception and print
   qualified, eg. `day = DayOfWeek.MONDAY`, which is valid Kotlin as long as the enum is

--- a/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
+++ b/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
@@ -18,23 +18,33 @@ fun <T>deepPrintPrimitive(value: T): String {
     }
 }
 
-fun String.deepPrint(indent: Int = 0): String = "${indent.indent()}\"$this\""
+/*
+ * These take a nullable receiver so that generated code does not have to special-case
+ * a nullable property: `val name: String?` and `val name: String` both come out of the
+ * processor as `${name.deepPrint()}`, and a null prints as the `null` literal.
+ */
 
-fun Byte.deepPrint(indent: Int = 0): String = "${indent.indent()}$this"
+fun String?.deepPrint(indent: Int = 0): String =
+    if (this == null) "${indent.indent()}null" else "${indent.indent()}\"$this\""
 
-fun Short.deepPrint(indent: Int = 0): String = "${indent.indent()}$this"
+fun Byte?.deepPrint(indent: Int = 0): String = "${indent.indent()}${this ?: "null"}"
 
-fun Int.deepPrint(indent: Int = 0): String = "${indent.indent()}$this"
+fun Short?.deepPrint(indent: Int = 0): String = "${indent.indent()}${this ?: "null"}"
 
-fun Long.deepPrint(indent: Int = 0): String = "${indent.indent()}$this"
+fun Int?.deepPrint(indent: Int = 0): String = "${indent.indent()}${this ?: "null"}"
 
-fun Double.deepPrint(indent: Int = 0): String = "${indent.indent()}${formatForJS()}"
+fun Long?.deepPrint(indent: Int = 0): String = "${indent.indent()}${this ?: "null"}"
 
-fun Boolean.deepPrint(indent: Int = 0): String = "${indent.indent()}$this"
+fun Double?.deepPrint(indent: Int = 0): String =
+    if (this == null) "${indent.indent()}null" else "${indent.indent()}${formatForJS()}"
 
-fun Char.deepPrint(indent: Int = 0): String = "${indent.indent()}'${this}'"
+fun Boolean?.deepPrint(indent: Int = 0): String = "${indent.indent()}${this ?: "null"}"
 
-fun Float.deepPrint(indent: Int = 0): String = "${indent.indent()}${formatForJS()}f"
+fun Char?.deepPrint(indent: Int = 0): String =
+    if (this == null) "${indent.indent()}null" else "${indent.indent()}'${this}'"
+
+fun Float?.deepPrint(indent: Int = 0): String =
+    if (this == null) "${indent.indent()}null" else "${indent.indent()}${formatForJS()}f"
 
 fun Int.indent(): String = " ".repeat(this)
 

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
@@ -52,7 +52,28 @@ class DeepPrintProcessor(
 
     companion object {
         private const val DATACLASS_MAP_VAL_INDENT_MULTIPLIER = 3
-        private const val PRIMITIVE_MAP_VAL_INDENT_MUTILPLIER = 2
+
+        private val PRIMITIVE_TYPES = setOf(
+            "String", "Byte", "Short", "Int", "Long", "Boolean", "Char", "Double", "Float",
+        )
+
+        private val COLLECTION_CONSTRUCTORS = mapOf(
+            "List" to "listOf",
+            "MutableList" to "mutableListOf",
+            "ArrayList" to "arrayListOf",
+            "Set" to "setOf",
+            "MutableSet" to "mutableSetOf",
+            "HashSet" to "hashSetOf",
+            "LinkedHashSet" to "linkedSetOf",
+            "Array" to "arrayOf",
+        )
+
+        private val MAP_CONSTRUCTORS = mapOf(
+            "Map" to "mapOf",
+            "MutableMap" to "mutableMapOf",
+            "HashMap" to "hashMapOf",
+            "LinkedHashMap" to "linkedMapOf",
+        )
 
         /**
          * Primitive arrays are not `Array<T>`: they carry no type argument and each
@@ -155,26 +176,7 @@ class DeepPrintProcessor(
                 props.forEach { propertyDeclaration ->
                     val type: KSType = propertyDeclaration.type.resolve()
                     functionStringBuilder.append("\${(currentIndent + indentWidth).indent()}${propertyDeclaration} = ")
-                    val propertyAssignment = when (type.declaration.simpleName.asString()) {
-                        "String", "Byte", "Short", "Int", "Long", "Boolean", "Char",
-                        "Double", "Float" -> "\${${propertyDeclaration}.deepPrint()},\n"
-                        "List", "MutableList", "ArrayList",
-                        "Set", "MutableSet", "HashSet", "LinkedHashSet", "Array" -> {
-                            processCollection(imports, type, propertyDeclaration)
-                        }
-                        in PRIMITIVE_ARRAY_CONSTRUCTORS -> {
-                            processPrimitiveArray(imports, type, propertyDeclaration)
-                        }
-                        "Map", "MutableMap", "HashMap", "LinkedHashMap" -> {
-                            processMap(imports, type, propertyDeclaration)
-                        }
-                        // Property assignment is an annotated data class (can deep print), 
-                        // or not (cannot deep print)
-                        else -> {
-                            processAnnotatedDataClassOrNotSupported(type, propertyDeclaration, imports)
-                        }
-                    }
-                    functionStringBuilder.append(propertyAssignment)
+                    functionStringBuilder.append(processProperty(imports, type, propertyDeclaration))
                 }
                 functionStringBuilder.append("\${currentIndent.indent()})")
                 functionStringBuilder.append("\"\"\"\n}")
@@ -186,59 +188,110 @@ class DeepPrintProcessor(
                     functionStringBuilder.toString()
         }
 
-        @OptIn(KspExperimental::class)
-        private fun processAnnotatedDataClassOrNotSupported(
+        /**
+         * Renders one property assignment, including the trailing comma and newline.
+         *
+         * Everything except the primitives goes through an expression that takes the
+         * property value as `value`. That is what makes a nullable property work: the
+         * expression is placed inside `?.let { }` and the whole assignment collapses to
+         * `null` when the value is absent, rather than the constructor call being
+         * emitted around nothing.
+         */
+        private fun processProperty(
+            imports: LinkedHashSet<String>,
             type: KSType,
             propertyDeclaration: KSPropertyDeclaration,
-            imports: LinkedHashSet<String>
         ): String {
-            // Not every declaration is a class: a typealias resolves to a KSTypeAlias.
-            // There is nothing to deep print in that case, so fall back to toString()
-            // the same way an unannotated class does, rather than throwing.
-            val propClassDeclaration = type.declaration as? KSClassDeclaration
-                ?: return "\$$propertyDeclaration,\n"
-            val propPackage = propClassDeclaration.packageName
-            val propPackageName = propPackage.asString()
-            // TODO(Support properties defined outside of the module)
-            return if (propClassDeclaration.isDataClass() &&
-                (propClassDeclaration.isAnnotationPresent(DeepPrint::class) ||
-                        propertyDeclaration.isAnnotationPresent(DeepPrint::class))
-            ) {
-                imports.add("import $propPackageName.deepPrint")
-                "\n\${${propertyDeclaration}.deepPrint(currentIndent + 2 * indentWidth)},\n"
-            } else { /* no annotation on property or class */
-                "\$$propertyDeclaration,\n"
+            val typeName = type.declaration.simpleName.asString()
+            // The primitive deepPrint() extensions take a nullable receiver already.
+            if (typeName in PRIMITIVE_TYPES) {
+                return "\${${propertyDeclaration}.deepPrint()},\n"
+            }
+            val expression = valueExpression(imports, type, receiver = "value", propertyDeclaration)
+            return when {
+                // Nothing we can render: a string template on a null prints "null" anyway.
+                expression == null -> "\$$propertyDeclaration,\n"
+                type.isMarkedNullable ->
+                    "\${$propertyDeclaration?.let { value -> $expression } ?: \"null\"},\n"
+                else -> "\${$propertyDeclaration.let { value -> $expression }},\n"
             }
         }
 
-        private fun processMap(
+        /**
+         * A Kotlin expression that evaluates to the printed form of [receiver], whose
+         * static type is [type]. Returns null when the type is not one DeepPrint knows
+         * how to reconstruct.
+         *
+         * [propertyDeclaration] is only consulted for the `@property:DeepPrint` case, so
+         * it is absent when rendering a value nested inside a collection.
+         */
+        @OptIn(KspExperimental::class)
+        private fun valueExpression(
             imports: LinkedHashSet<String>,
             type: KSType,
-            propertyDeclaration: KSPropertyDeclaration
+            receiver: String,
+            propertyDeclaration: KSPropertyDeclaration? = null,
+        ): String? {
+            val typeName = type.declaration.simpleName.asString()
+            return when {
+                typeName in PRIMITIVE_TYPES -> "$receiver.deepPrint()"
+                typeName in COLLECTION_CONSTRUCTORS -> collectionExpression(imports, type, receiver)
+                typeName in PRIMITIVE_ARRAY_CONSTRUCTORS -> primitiveArrayExpression(imports, type, receiver)
+                typeName in MAP_CONSTRUCTORS -> mapExpression(imports, type, receiver)
+                else -> annotatedDataClassExpression(imports, type, receiver, propertyDeclaration)
+            }
+        }
+
+        @OptIn(KspExperimental::class)
+        private fun annotatedDataClassExpression(
+            imports: LinkedHashSet<String>,
+            type: KSType,
+            receiver: String,
+            propertyDeclaration: KSPropertyDeclaration?,
+        ): String? {
+            // Not every declaration is a class: a typealias resolves to a KSTypeAlias.
+            // There is nothing to deep print in that case, so fall back to toString()
+            // the same way an unannotated class does, rather than throwing.
+            val propClassDeclaration = type.declaration as? KSClassDeclaration ?: return null
+            val propPackageName = propClassDeclaration.packageName.asString()
+            // TODO(Support properties defined outside of the module)
+            val annotated = propClassDeclaration.isDataClass() &&
+                (propClassDeclaration.isAnnotationPresent(DeepPrint::class) ||
+                    propertyDeclaration?.isAnnotationPresent(DeepPrint::class) == true)
+            return if (annotated) {
+                imports.add("import $propPackageName.deepPrint")
+                "\"\\n\" + $receiver.deepPrint(currentIndent + 2 * indentWidth)"
+            } else {
+                null
+            }
+        }
+
+        private fun mapExpression(
+            imports: LinkedHashSet<String>,
+            type: KSType,
+            receiver: String,
         ): String {
             imports.add("import com.bradyaiello.deepprint.deepPrintContents")
             val ksKeyTypeRef: KSTypeReference = type.arguments[0].type!!
             val ksValueTypeRef: KSTypeReference = type.arguments[1].type!!
-            val valueDecl = ksValueTypeRef.resolve().declaration
-            val mapConstructor = when (type.declaration.simpleName.asString()) {
-                "Map" -> "mapOf"
-                "HashMap" -> "hashMapOf"
-                "LinkedHashMap" -> "linkedMapOf"
-                else  -> "mutableMapOf"
-            }
-            val opening = "$mapConstructor<$ksKeyTypeRef,$ksValueTypeRef>(\n"
+            val valueType = ksValueTypeRef.resolve()
+            val mapConstructor = MAP_CONSTRUCTORS.getValue(type.declaration.simpleName.asString())
 
-            val indentMultiplier = if (valueDecl.isDeepPrintAnnotatedDataClass()) 
-                DATACLASS_MAP_VAL_INDENT_MULTIPLIER 
-            else PRIMITIVE_MAP_VAL_INDENT_MUTILPLIER
-            
-            val valueTransform = if (valueDecl.isDeepPrintAnnotatedDataClass()) 
-                "\"\\n\" + it.deepPrint(currentIndent + $indentMultiplier * indentWidth)" 
-                else "it.deepPrint()"
-            val entriesPrint =  "\${${propertyDeclaration}.deepPrintContents(\nkeyTransform = " +
-                    "{(currentIndent + 2 * indentWidth).indent() + it.deepPrint() },\n" +
-                    "valueTransform = { $valueTransform })}\${(currentIndent + indentWidth).indent()}),\n"
-            return opening + entriesPrint
+            val valueTransform = if (valueType.declaration.isDeepPrintAnnotatedDataClass()) {
+                // A data class value opens a block, so it sits a level deeper than a
+                // value that prints inline next to its key.
+                "\"\\n\" + it.deepPrint(currentIndent + $DATACLASS_MAP_VAL_INDENT_MULTIPLIER * indentWidth)"
+            } else {
+                // Anything else -- including a collection, which has no deepPrint() of
+                // its own and used to generate code that did not compile.
+                valueExpression(imports, valueType, receiver = "it") ?: "it.toString()"
+            }
+
+            return "\"$mapConstructor<$ksKeyTypeRef,$ksValueTypeRef>(\\n\" + " +
+                "$receiver.deepPrintContents(\n" +
+                "keyTransform = { key -> (currentIndent + 2 * indentWidth).indent() + key.deepPrint() },\n" +
+                "valueTransform = { $valueTransform }) + " +
+                "(currentIndent + indentWidth).indent() + \")\""
         }
 
         /**
@@ -248,50 +301,40 @@ class DeepPrintProcessor(
          * mutableSetOf() or arrayOf() function call.
          */
         @OptIn(KspExperimental::class)
-        private fun processCollection(
+        private fun collectionExpression(
             imports: LinkedHashSet<String>,
             type: KSType,
-            propertyDeclaration: KSPropertyDeclaration
+            receiver: String,
         ): String {
             imports.add("import com.bradyaiello.deepprint.deepPrintContents")
-            val ksTypeArg = type.arguments[0]
-            val itemType = ksTypeArg.type!!
-            val paramHasDeepPrintAnnotation =
-                ksTypeArg.type!!.resolve().declaration.isAnnotationPresent(DeepPrint::class)
-            val collectionConstructor = when (type.declaration.simpleName.asString()) {
-                "MutableList" -> "mutableListOf"
-                "List" -> "listOf"
-                "ArrayList" -> "arrayListOf"
-                "MutableSet" -> "mutableSetOf"
-                "Set" -> "setOf"
-                "HashSet" -> "hashSetOf"
-                "LinkedHashSet" -> "linkedSetOf"
-                else -> "arrayOf"
-            }
-            val opening = "$collectionConstructor<${itemType}>("
-            val itemsPrint: String = if (paramHasDeepPrintAnnotation) {
-                "\n\${$propertyDeclaration.joinToString(separator = \"\") " +
-                        "{ it.deepPrint(currentIndent = currentIndent + 2 * indentWidth) + \",\\n\" }}" +
-                        "\${(currentIndent + indentWidth).indent()}),\n"
+            val itemType = type.arguments[0].type!!
+            val itemIsAnnotated = itemType.resolve().declaration.isAnnotationPresent(DeepPrint::class)
+            val collectionConstructor =
+                COLLECTION_CONSTRUCTORS.getValue(type.declaration.simpleName.asString())
+
+            return if (itemIsAnnotated) {
+                "\"$collectionConstructor<${itemType}>(\\n\" + " +
+                    "$receiver.joinToString(separator = \"\") " +
+                    "{ item -> item.deepPrint(currentIndent = currentIndent + 2 * indentWidth) + \",\\n\" } + " +
+                    "(currentIndent + indentWidth).indent() + \")\""
             } else {
-                "\${$propertyDeclaration.deepPrintContents()}),\n"
+                "\"$collectionConstructor<${itemType}>(\" + $receiver.deepPrintContents() + \")\""
             }
-            return opening + itemsPrint
         }
 
         /**
          * Processes IntArray, LongArray and friends. They have no type argument,
          * so the element type is baked into the factory function name.
          */
-        private fun processPrimitiveArray(
+        private fun primitiveArrayExpression(
             imports: LinkedHashSet<String>,
             type: KSType,
-            propertyDeclaration: KSPropertyDeclaration
+            receiver: String,
         ): String {
             imports.add("import com.bradyaiello.deepprint.deepPrintContents")
             val arrayConstructor =
                 PRIMITIVE_ARRAY_CONSTRUCTORS.getValue(type.declaration.simpleName.asString())
-            return "$arrayConstructor(\${$propertyDeclaration.deepPrintContents()}),\n"
+            return "\"$arrayConstructor(\" + $receiver.deepPrintContents() + \")\""
         }
 
         private fun KSDeclaration.isDeepPrintAnnotatedDataClass(): Boolean {

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -128,6 +128,22 @@ data class WithJdkCollections(
 data class WithTypeAliasProperty(val person: PersonAlias)
 
 @DeepPrint
+data class WithNullables(
+    val name: String?,
+    val count: Int?,
+    val items: List<Int>?,
+    val someMap: Map<Int, String>?,
+    val ints: IntArray?,
+    val person: SamplePersonClass?,
+)
+
+@DeepPrint
+data class WithCollectionMapValues(
+    val listsByName: Map<String, List<Int>>,
+    val setsByName: Map<String, Set<String>>,
+)
+
+@DeepPrint
 data class WithAMap(
     val id: Long,
     val someMap: Map<Int, String>

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -19,6 +19,7 @@ import com.bradyaiello.deepprint.testclasses.WithAMutableSet
 import com.bradyaiello.deepprint.testclasses.WithASet
 import com.bradyaiello.deepprint.testclasses.WithAnArray
 import com.bradyaiello.deepprint.testclasses.WithAnnotatedProperty
+import com.bradyaiello.deepprint.testclasses.WithCollectionMapValues
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableArray
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
@@ -27,6 +28,7 @@ import com.bradyaiello.deepprint.testclasses.WithDeepPrintableSet
 import com.bradyaiello.deepprint.testclasses.WithJdkCollections
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
+import com.bradyaiello.deepprint.testclasses.WithNullables
 import com.bradyaiello.deepprint.testclasses.WithPrimitiveArrays
 import com.bradyaiello.deepprint.testclasses.WithTypeAliasProperty
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
@@ -169,6 +171,29 @@ val withJdkCollections = WithJdkCollections(
 )
 
 val withTypeAliasProperty = WithTypeAliasProperty(person = person)
+
+val withNullablesEmpty = WithNullables(
+    name = null,
+    count = null,
+    items = null,
+    someMap = null,
+    ints = null,
+    person = null,
+)
+
+val withNullablesPopulated = WithNullables(
+    name = "Dave",
+    count = 3,
+    items = listOf(0, 1),
+    someMap = mapOf(1 to "a"),
+    ints = intArrayOf(7, 8),
+    person = person,
+)
+
+val withCollectionMapValues = WithCollectionMapValues(
+    listsByName = mapOf("a" to listOf(1, 2)),
+    setsByName = mapOf("b" to setOf("x", "y")),
+)
 
 val withAnnotatedProperty = WithAnnotatedProperty(
     label = "some label",

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -18,12 +18,15 @@ import com.bradyaiello.deepprint.testobjects.withASet
 import com.bradyaiello.deepprint.testobjects.withAnArray
 import com.bradyaiello.deepprint.testobjects.withAnEmptyDeepPrintableSet
 import com.bradyaiello.deepprint.testobjects.withAnnotatedProperty
+import com.bradyaiello.deepprint.testobjects.withCollectionMapValues
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableArray
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableSet
 import com.bradyaiello.deepprint.testobjects.withJdkCollections
+import com.bradyaiello.deepprint.testobjects.withNullablesEmpty
+import com.bradyaiello.deepprint.testobjects.withNullablesPopulated
 import com.bradyaiello.deepprint.testobjects.withPrimitiveArrays
 import com.bradyaiello.deepprint.testobjects.withTypeAliasProperty
 import kotlin.test.Test
@@ -397,6 +400,68 @@ class BasicTest {
         """.trimIndent()
 
         val actual = withTypeAliasProperty.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun nullablePropertiesWhenAbsent() {
+        val expected = """
+            WithNullables(
+              name = null,
+              count = null,
+              items = null,
+              someMap = null,
+              ints = null,
+              person = null,
+            )
+        """.trimIndent()
+
+        val actual = withNullablesEmpty.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun nullablePropertiesWhenPresent() {
+        val expected = """
+            WithNullables(
+              name = "Dave",
+              count = 3,
+              items = listOf<Int>( 0, 1,),
+              someMap = mapOf<Int,String>(
+                1 to "a",
+              ),
+              ints = intArrayOf( 7, 8,),
+              person = 
+                SamplePersonClass(
+                  name = "Dave",
+                  sampleClass = 
+                    SampleClass(
+                      x = 0.5f,
+                      y = 2.6f,
+                      name = "A point",
+                    ),
+                ),
+            )
+        """.trimIndent()
+
+        val actual = withNullablesPopulated.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun mapWithCollectionValues() {
+        val expected = """
+            WithCollectionMapValues(
+              listsByName = mapOf<String,List<Int>>(
+                "a" to listOf<Int>( 1, 2,),
+              ),
+              setsByName = mapOf<String,Set<String>>(
+                "b" to setOf<String>( "x", "y",),
+              ),
+            )
+        """.trimIndent()
+
+        val actual = withCollectionMapValues.deepPrint()
         assertEquals(expected, actual)
     }
 

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -18,12 +18,15 @@ import com.bradyaiello.deepprint.testobjects.withASet
 import com.bradyaiello.deepprint.testobjects.withAnArray
 import com.bradyaiello.deepprint.testobjects.withAnEmptyDeepPrintableSet
 import com.bradyaiello.deepprint.testobjects.withAnnotatedProperty
+import com.bradyaiello.deepprint.testobjects.withCollectionMapValues
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableArray
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableSet
 import com.bradyaiello.deepprint.testobjects.withJdkCollections
+import com.bradyaiello.deepprint.testobjects.withNullablesEmpty
+import com.bradyaiello.deepprint.testobjects.withNullablesPopulated
 import com.bradyaiello.deepprint.testobjects.withPrimitiveArrays
 import com.bradyaiello.deepprint.testobjects.withTypeAliasProperty
 import kotlin.test.Test
@@ -397,6 +400,68 @@ class BasicTest {
         """.trimIndent()
 
         val actual = withTypeAliasProperty.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun nullablePropertiesWhenAbsent() {
+        val expected = """
+            WithNullables(
+                name = null,
+                count = null,
+                items = null,
+                someMap = null,
+                ints = null,
+                person = null,
+            )
+        """.trimIndent()
+
+        val actual = withNullablesEmpty.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun nullablePropertiesWhenPresent() {
+        val expected = """
+            WithNullables(
+                name = "Dave",
+                count = 3,
+                items = listOf<Int>( 0, 1,),
+                someMap = mapOf<Int,String>(
+                    1 to "a",
+                ),
+                ints = intArrayOf( 7, 8,),
+                person = 
+                    SamplePersonClass(
+                        name = "Dave",
+                        sampleClass = 
+                            SampleClass(
+                                x = 0.5f,
+                                y = 2.6f,
+                                name = "A point",
+                            ),
+                    ),
+            )
+        """.trimIndent()
+
+        val actual = withNullablesPopulated.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun mapWithCollectionValues() {
+        val expected = """
+            WithCollectionMapValues(
+                listsByName = mapOf<String,List<Int>>(
+                    "a" to listOf<Int>( 1, 2,),
+                ),
+                setsByName = mapOf<String,Set<String>>(
+                    "b" to setOf<String>( "x", "y",),
+                ),
+            )
+        """.trimIndent()
+
+        val actual = withCollectionMapValues.deepPrint()
         assertEquals(expected, actual)
     }
 

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -127,6 +127,22 @@ data class WithJdkCollections(
 data class WithTypeAliasProperty(val person: PersonAlias)
 
 @DeepPrint
+data class WithNullables(
+    val name: String?,
+    val count: Int?,
+    val items: List<Int>?,
+    val someMap: Map<Int, String>?,
+    val ints: IntArray?,
+    val person: SamplePersonClass?,
+)
+
+@DeepPrint
+data class WithCollectionMapValues(
+    val listsByName: Map<String, List<Int>>,
+    val setsByName: Map<String, Set<String>>,
+)
+
+@DeepPrint
 data class WithAMap(
     val id: Long,
     val someMap: Map<Int, String>

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -19,6 +19,7 @@ import com.bradyaiello.deepprint.testclasses.WithAMutableSet
 import com.bradyaiello.deepprint.testclasses.WithASet
 import com.bradyaiello.deepprint.testclasses.WithAnArray
 import com.bradyaiello.deepprint.testclasses.WithAnnotatedProperty
+import com.bradyaiello.deepprint.testclasses.WithCollectionMapValues
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableArray
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
@@ -27,6 +28,7 @@ import com.bradyaiello.deepprint.testclasses.WithDeepPrintableSet
 import com.bradyaiello.deepprint.testclasses.WithJdkCollections
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
+import com.bradyaiello.deepprint.testclasses.WithNullables
 import com.bradyaiello.deepprint.testclasses.WithPrimitiveArrays
 import com.bradyaiello.deepprint.testclasses.WithTypeAliasProperty
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
@@ -169,6 +171,29 @@ val withJdkCollections = WithJdkCollections(
 )
 
 val withTypeAliasProperty = WithTypeAliasProperty(person = person)
+
+val withNullablesEmpty = WithNullables(
+    name = null,
+    count = null,
+    items = null,
+    someMap = null,
+    ints = null,
+    person = null,
+)
+
+val withNullablesPopulated = WithNullables(
+    name = "Dave",
+    count = 3,
+    items = listOf(0, 1),
+    someMap = mapOf(1 to "a"),
+    ints = intArrayOf(7, 8),
+    person = person,
+)
+
+val withCollectionMapValues = WithCollectionMapValues(
+    listsByName = mapOf("a" to listOf(1, 2)),
+    setsByName = mapOf("b" to setOf("x", "y")),
+)
 
 val withAnnotatedProperty = WithAnnotatedProperty(
     label = "some label",


### PR DESCRIPTION
The two KSP gaps that made the processor emit code that doesn't compile.

## Nullable properties

`val name: String?` generated `${name.deepPrint()}`; `val items: List<Int>?` generated `listOf<Int>(${items.deepPrintContents()})`. Both fail with *Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver*.

Primitives are handled in the annotations module: the nine `deepPrint()` extensions take a nullable receiver now and print the `null` literal, so generated code doesn't have to distinguish `String` from `String?` at all. Everything else needed the processor change described below.

```kotlin
Maybe(
    name = null,
    items = null,
    person = null,
)
```

## Collections as map values

`Map<String, List<Int>>` generated `valueTransform = { it.deepPrint() }`, and there is no `List<Int>.deepPrint()`. The value transform is chosen from the value's static type now:

```kotlin
listsByName = mapOf<String,List<Int>>(
    "a" to listOf<Int>( 1, 2,),
),
```

## The change behind both

The four renderers used to emit template text with the property name baked in. They now return a Kotlin **expression** parameterised by a receiver name, and the caller decides how to invoke it:

```kotlin
// non-null
${prop.let { value -> <expr> }}
// nullable
${prop?.let { value -> <expr> } ?: "null"}
```

That's what lets the whole assignment collapse to `null`, rather than the constructor call being emitted around nothing. Parameterising by receiver is also what makes a collection work as a map value — the same expression is generated with `it` as the receiver inside `valueTransform`. The two fixes are one change.

**Output for every previously supported type is byte-identical.** The 25 existing tests passed untouched through the refactor, before the three new ones went in — that was the check I wanted before trusting it.

## Tests

Three new cases in both test projects: a class of nullable properties with everything absent, the same class fully populated, and a map with `List` and `Set` values.

28 pass in `test-project` and in `test-project-multiplatform` on `jvmTest`, `jsNodeTest`, `macosArm64Test` and `watchosSimulatorArm64Test`. Reflection's 29 still pass; `detekt` is clean.

## Rebased on #29

#29 landed first, so this hit the README conflict predicted above and has been rebased. The resolution: with both PRs in, nullable properties work in *both* implementations, so the limitation bullet is gone entirely rather than reworded — #29's reflection-fallback bullet stays as it was. Code never overlapped (different modules).

Re-verified after the rebase: 28 KSP tests on all four targets, reflection's 33, detekt clean.

## Still open

From the gap list, deliberately left for a follow-up: nested collections (`List<List<Int>>`), enums, unsigned types, `Collection`/`Iterable`/`Sequence`, `Pair`/`Triple`, and typealias resolution.
