### PR TITLE
KSP: print enum constants qualified

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,25 @@ listsByName = mapOf<String,List<Int>>(
 ),
 ```
 
+### KSP and Enums
+
+An enum property prints qualified, so the output is valid Kotlin as long as the enum is
+imported where you paste it. This holds wherever the enum appears -- as a property, as a
+collection item, and as a map key or value:
+
+```kotlin
+WithEnums(
+    direction = Direction.NORTH,
+    directions = listOf<Direction>( Direction.NORTH, Direction.SOUTH,),
+    bySide = mapOf<Direction,String>(
+        Direction.NORTH to "up",
+    ),
+)
+```
+
+An enum nested in another class prints with its own simple name, eg. `Color.RED` for
+`Outer.Color`, so `import com.example.Outer.Color` is what makes that output compile.
+
 ### KSP and Nullable Properties
 
 A nullable property prints as the `null` literal when it is absent, and normally when

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
@@ -11,6 +11,7 @@ import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSCallableReference
 import com.google.devtools.ksp.symbol.KSClassDeclaration
@@ -238,7 +239,25 @@ class DeepPrintProcessor(
                 typeName in COLLECTION_CONSTRUCTORS -> collectionExpression(imports, type, receiver)
                 typeName in PRIMITIVE_ARRAY_CONSTRUCTORS -> primitiveArrayExpression(imports, type, receiver)
                 typeName in MAP_CONSTRUCTORS -> mapExpression(imports, type, receiver)
-                else -> annotatedDataClassExpression(imports, type, receiver, propertyDeclaration)
+                else -> enumExpression(type, receiver)
+                    ?: annotatedDataClassExpression(imports, type, receiver, propertyDeclaration)
+            }
+        }
+
+        /**
+         * Enum constants print qualified, as `Direction.NORTH`, which is valid Kotlin as
+         * long as the enum is imported where the output is pasted. The generated code
+         * only needs the constant's own `name`, so nothing has to be imported into the
+         * generated file itself.
+         *
+         * Returns null when [type] is not an enum.
+         */
+        private fun enumExpression(type: KSType, receiver: String): String? {
+            val declaration = type.declaration as? KSClassDeclaration
+            return if (declaration?.classKind == ClassKind.ENUM_CLASS) {
+                "\"${declaration.simpleName.asString()}.\" + $receiver.name"
+            } else {
+                null
             }
         }
 
@@ -276,6 +295,9 @@ class DeepPrintProcessor(
             val ksValueTypeRef: KSTypeReference = type.arguments[1].type!!
             val valueType = ksValueTypeRef.resolve()
             val mapConstructor = MAP_CONSTRUCTORS.getValue(type.declaration.simpleName.asString())
+            // A primitive key has deepPrint(); an enum key does not, and used to generate
+            // code that did not compile.
+            val keyTransform = enumExpression(ksKeyTypeRef.resolve(), "key") ?: "key.deepPrint()"
 
             val valueTransform = if (valueType.declaration.isDeepPrintAnnotatedDataClass()) {
                 // A data class value opens a block, so it sits a level deeper than a
@@ -289,7 +311,7 @@ class DeepPrintProcessor(
 
             return "\"$mapConstructor<$ksKeyTypeRef,$ksValueTypeRef>(\\n\" + " +
                 "$receiver.deepPrintContents(\n" +
-                "keyTransform = { key -> (currentIndent + 2 * indentWidth).indent() + key.deepPrint() },\n" +
+                "keyTransform = { key -> (currentIndent + 2 * indentWidth).indent() + ($keyTransform) },\n" +
                 "valueTransform = { $valueTransform }) + " +
                 "(currentIndent + indentWidth).indent() + \")\""
         }
@@ -308,17 +330,27 @@ class DeepPrintProcessor(
         ): String {
             imports.add("import com.bradyaiello.deepprint.deepPrintContents")
             val itemType = type.arguments[0].type!!
-            val itemIsAnnotated = itemType.resolve().declaration.isAnnotationPresent(DeepPrint::class)
+            val resolvedItemType = itemType.resolve()
+            val itemIsAnnotated = resolvedItemType.declaration.isAnnotationPresent(DeepPrint::class)
+            val itemEnum = enumExpression(resolvedItemType, "item")
             val collectionConstructor =
                 COLLECTION_CONSTRUCTORS.getValue(type.declaration.simpleName.asString())
 
-            return if (itemIsAnnotated) {
-                "\"$collectionConstructor<${itemType}>(\\n\" + " +
-                    "$receiver.joinToString(separator = \"\") " +
-                    "{ item -> item.deepPrint(currentIndent = currentIndent + 2 * indentWidth) + \",\\n\" } + " +
-                    "(currentIndent + indentWidth).indent() + \")\""
-            } else {
-                "\"$collectionConstructor<${itemType}>(\" + $receiver.deepPrintContents() + \")\""
+            return when {
+                itemIsAnnotated ->
+                    "\"$collectionConstructor<${itemType}>(\\n\" + " +
+                        "$receiver.joinToString(separator = \"\") " +
+                        "{ item -> item.deepPrint(currentIndent = currentIndent + 2 * indentWidth) + \",\\n\" } + " +
+                        "(currentIndent + indentWidth).indent() + \")\""
+                // deepPrintContents() renders items from their runtime type, which for an
+                // enum means an unqualified toString(). The item type is known here, so
+                // the items are laid out directly instead, in the same shape.
+                itemEnum != null ->
+                    "\"$collectionConstructor<${itemType}>(\" + " +
+                        "$receiver.joinToString(separator = \"\") { item -> \" \" + ($itemEnum) + \",\" } + " +
+                        "\")\""
+                else ->
+                    "\"$collectionConstructor<${itemType}>(\" + $receiver.deepPrintContents() + \")\""
             }
         }
 

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -143,6 +143,17 @@ data class WithCollectionMapValues(
     val setsByName: Map<String, Set<String>>,
 )
 
+enum class Direction { NORTH, SOUTH }
+
+@DeepPrint
+data class WithEnums(
+    val direction: Direction,
+    val maybeDirection: Direction?,
+    val directions: List<Direction>,
+    val bySide: Map<Direction, String>,
+    val toDirections: Map<String, List<Direction>>,
+)
+
 @DeepPrint
 data class WithAMap(
     val id: Long,

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -1,6 +1,7 @@
 package com.bradyaiello.deepprint.testobjects
 
 import com.bradyaiello.deepprint.testclasses.AllTypes
+import com.bradyaiello.deepprint.testclasses.Direction
 import com.bradyaiello.deepprint.testclasses.Name
 import com.bradyaiello.deepprint.testclasses.SampleClass
 import com.bradyaiello.deepprint.testclasses.SamplePersonClass
@@ -25,6 +26,7 @@ import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableSet
+import com.bradyaiello.deepprint.testclasses.WithEnums
 import com.bradyaiello.deepprint.testclasses.WithJdkCollections
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
@@ -193,6 +195,14 @@ val withNullablesPopulated = WithNullables(
 val withCollectionMapValues = WithCollectionMapValues(
     listsByName = mapOf("a" to listOf(1, 2)),
     setsByName = mapOf("b" to setOf("x", "y")),
+)
+
+val withEnums = WithEnums(
+    direction = Direction.NORTH,
+    maybeDirection = null,
+    directions = listOf(Direction.NORTH, Direction.SOUTH),
+    bySide = mapOf(Direction.NORTH to "up"),
+    toDirections = mapOf("all" to listOf(Direction.NORTH, Direction.SOUTH)),
 )
 
 val withAnnotatedProperty = WithAnnotatedProperty(

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -24,6 +24,7 @@ import com.bradyaiello.deepprint.testobjects.withDeepPrintableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableSet
+import com.bradyaiello.deepprint.testobjects.withEnums
 import com.bradyaiello.deepprint.testobjects.withJdkCollections
 import com.bradyaiello.deepprint.testobjects.withNullablesEmpty
 import com.bradyaiello.deepprint.testobjects.withNullablesPopulated
@@ -462,6 +463,26 @@ class BasicTest {
         """.trimIndent()
 
         val actual = withCollectionMapValues.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun enumsPrintQualified() {
+        val expected = """
+            WithEnums(
+              direction = Direction.NORTH,
+              maybeDirection = null,
+              directions = listOf<Direction>( Direction.NORTH, Direction.SOUTH,),
+              bySide = mapOf<Direction,String>(
+                Direction.NORTH to "up",
+              ),
+              toDirections = mapOf<String,List<Direction>>(
+                "all" to listOf<Direction>( Direction.NORTH, Direction.SOUTH,),
+              ),
+            )
+        """.trimIndent()
+
+        val actual = withEnums.deepPrint()
         assertEquals(expected, actual)
     }
 

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -24,6 +24,7 @@ import com.bradyaiello.deepprint.testobjects.withDeepPrintableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableList
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testobjects.withDeepPrintableSet
+import com.bradyaiello.deepprint.testobjects.withEnums
 import com.bradyaiello.deepprint.testobjects.withJdkCollections
 import com.bradyaiello.deepprint.testobjects.withNullablesEmpty
 import com.bradyaiello.deepprint.testobjects.withNullablesPopulated
@@ -462,6 +463,26 @@ class BasicTest {
         """.trimIndent()
 
         val actual = withCollectionMapValues.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun enumsPrintQualified() {
+        val expected = """
+            WithEnums(
+                direction = Direction.NORTH,
+                maybeDirection = null,
+                directions = listOf<Direction>( Direction.NORTH, Direction.SOUTH,),
+                bySide = mapOf<Direction,String>(
+                    Direction.NORTH to "up",
+                ),
+                toDirections = mapOf<String,List<Direction>>(
+                    "all" to listOf<Direction>( Direction.NORTH, Direction.SOUTH,),
+                ),
+            )
+        """.trimIndent()
+
+        val actual = withEnums.deepPrint()
         assertEquals(expected, actual)
     }
 

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -142,6 +142,17 @@ data class WithCollectionMapValues(
     val setsByName: Map<String, Set<String>>,
 )
 
+enum class Direction { NORTH, SOUTH }
+
+@DeepPrint
+data class WithEnums(
+    val direction: Direction,
+    val maybeDirection: Direction?,
+    val directions: List<Direction>,
+    val bySide: Map<Direction, String>,
+    val toDirections: Map<String, List<Direction>>,
+)
+
 @DeepPrint
 data class WithAMap(
     val id: Long,

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -1,6 +1,7 @@
 package com.bradyaiello.deepprint.testobjects
 
 import com.bradyaiello.deepprint.testclasses.AllTypes
+import com.bradyaiello.deepprint.testclasses.Direction
 import com.bradyaiello.deepprint.testclasses.Name
 import com.bradyaiello.deepprint.testclasses.SampleClass
 import com.bradyaiello.deepprint.testclasses.SamplePersonClass
@@ -25,6 +26,7 @@ import com.bradyaiello.deepprint.testclasses.WithDeepPrintableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableSet
+import com.bradyaiello.deepprint.testclasses.WithEnums
 import com.bradyaiello.deepprint.testclasses.WithJdkCollections
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
@@ -193,6 +195,14 @@ val withNullablesPopulated = WithNullables(
 val withCollectionMapValues = WithCollectionMapValues(
     listsByName = mapOf("a" to listOf(1, 2)),
     setsByName = mapOf("b" to setOf("x", "y")),
+)
+
+val withEnums = WithEnums(
+    direction = Direction.NORTH,
+    maybeDirection = null,
+    directions = listOf(Direction.NORTH, Direction.SOUTH),
+    bySide = mapOf(Direction.NORTH to "up"),
+    toDirections = mapOf("all" to listOf(Direction.NORTH, Direction.SOUTH)),
 )
 
 val withAnnotatedProperty = WithAnnotatedProperty(


### PR DESCRIPTION
> Was stacked on #30, which has now merged. Rebased onto `main` — the diff is enums only.

An enum property printed as the bare constant:

```kotlin
day = MONDAY,
```

which only compiles if `MONDAY` happens to be imported by name. It prints `Direction.NORTH` now — valid Kotlin once the enum itself is imported.

## An enum map key didn't compile at all

`keyTransform` was hardcoded to `key.deepPrint()`, and there's no such extension for an enum, so `Map<Direction, String>` generated:

```
DeepPrintProbeEnumKey.kt:11:74 None of the following candidates is applicable
```

I only found that while writing the tests for this — it belonged in the blocker slice. The key transform is chosen from the key's static type now.

## Three places, one renderer

All reached through `valueExpression()`:

- **as a property**, including a nullable one — #30's `?.let` wrapper handles that for free
- **as a collection item.** `deepPrintContents()` renders items from their *runtime* type, so an enum went through `toString()` unqualified. The item type is known statically here, so the items are laid out directly instead, in the same shape `deepPrintContents()` produces — output for every other element type is unchanged
- **as a map key or value**

Generated code never references the enum type, only the constant's own `name`, so nothing has to be imported into the generated file.

## Nested enums

An enum nested in another class prints with its own simple name — `Color.RED` for `Outer.Color`. That matches what the reflection implementation does after #29, and `import com.example.Outer.Color` makes it compile.

## Tests

One new case covering all four positions at once: property, nullable property, `List<Direction>`, `Map<Direction, String>`, and `Map<String, List<Direction>>`.

29 pass in `test-project` and in `test-project-multiplatform` on `jvmTest`, `jsNodeTest`, `macosArm64Test` and `watchosSimulatorArm64Test`. Reflection's 29 still pass; `detekt` is clean.
