### PR TITLE
Support Pair/Triple, Collection/Iterable/Sequence, unsigned types and typealiases

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ A property whose type is one of these is printed as the call that rebuilds it:
 | `LinkedHashSet<T>` | `linkedSetOf<T>(...)` |
 | `HashMap<K, V>` | `hashMapOf<K, V>(...)` |
 | `LinkedHashMap<K, V>` | `linkedMapOf<K, V>(...)` |
+| `Collection<T>`, `Iterable<T>` | `listOf<T>(...)` |
+| `Sequence<T>` | `sequenceOf<T>(...)` |
+| `UByteArray`, `UShortArray`, `UIntArray`, `ULongArray` | `ubyteArrayOf(...)`, `ushortArrayOf(...)`, `uintArrayOf(...)`, `ulongArrayOf(...)` |
+| `Pair<A, B>`, `Triple<A, B, C>` | `Pair(a, b)`, `Triple(a, b, c)` |
 | `ByteArray`, `ShortArray`, `IntArray`, `LongArray` | `byteArrayOf(...)`, `shortArrayOf(...)`, `intArrayOf(...)`, `longArrayOf(...)` |
 | `FloatArray`, `DoubleArray`, `BooleanArray`, `CharArray` | `floatArrayOf(...)`, `doubleArrayOf(...)`, `booleanArrayOf(...)`, `charArrayOf(...)` |
 
@@ -274,6 +278,31 @@ WithEnums(
 
 An enum nested in another class prints with its own simple name, eg. `Color.RED` for
 `Outer.Color`, so `import com.example.Outer.Color` is what makes that output compile.
+
+### KSP and the Remaining Types
+
+`Pair` and `Triple` print as constructor calls on one line, with each component
+rendered by its own type:
+
+```kotlin
+pair = Pair("a", 1),
+triple = Triple(1, true, 'x'),
+```
+
+The unsigned types print with the `u` suffix, so the value is assignable back to a
+`UInt` rather than being read as an `Int`:
+
+```kotlin
+int = 3u,
+ints = uintArrayOf( 5u, 6u,),
+```
+
+A `typealias` without type arguments is resolved, so `typealias IntList = List<Int>`
+prints as a list, and an alias for an annotated `data class` deep prints rather than
+falling back to `toString()`.
+
+`Sequence` is supported, but note that printing one **consumes it**. A sequence that
+can only be iterated once is spent by printing it.
 
 ### KSP and Nullable Properties
 
@@ -464,23 +493,17 @@ That is not true for single source projects, like [test-project](./test-project)
   [KSP and Collection Types](#KSP-and-Collection-Types) for what KSP handles, and
   [Reflection and Collection Types](#Reflection-and-Collection-Types) for reflection.
   Still missing, in both implementations:
-  - `Collection`, `Iterable` and `Sequence` properties, and `Pair` and `Triple`.
-    These fall back to `toString()`, so the output is readable but is not a
-    constructor call.
   - Nested collections, eg. `List<List<Int>>`. The outer collection prints correctly,
     but the inner one prints via `toString()` as `[0, 1]`, which is not valid Kotlin.
     A collection as a *map value*, eg. `Map<String, List<Int>>`, does work.
-  - The unsigned arrays `UByteArray`, `UShortArray`, `UIntArray` and `ULongArray`.
-  - A property whose type is a `typealias` for a `@DeepPrint` `data class`. The alias
-    is not resolved, so the property falls back to `toString()`.
+  - A *generic* `typealias`, eg. `typealias Mapping<V> = Map<String, V>`. The aliased
+    type still carries the unsubstituted parameter, so it is left alone and falls back
+    to `toString()`. A typealias without type arguments is resolved and printed
+    normally.
 - For reflection, a property that is neither a primitive, a supported collection, nor a
   `data class` is printed with `toString()`. Enums are the exception and print
   qualified, eg. `day = DayOfWeek.MONDAY`, which is valid Kotlin as long as the enum is
   imported.
-- On Kotlin/JS, `Float`, `Double` and `Char` elements of a `List`, `Set` or `Array` are
-  identified by their runtime type, which JS erases to a number. `2.0f` prints as `2` and
-  `'A'` prints as `65`. `FloatArray`, `DoubleArray` and `CharArray` are not affected, and
-  neither are properties declared directly on a `data class`.
 - In KMP projects, KSP [does not yet support](https://github.com/google/ksp/issues/567) generating code from the 
   `commonTest` source set. Hence, test classes for the KMP test project are in `commonMain`.
 

--- a/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
+++ b/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
@@ -6,6 +6,10 @@ import kotlin.math.floor
 fun <T>deepPrintPrimitive(value: T): String {
     return when (value) {
         is String -> "\"$value\""
+        is UByte,
+        is UShort,
+        is UInt,
+        is ULong -> "${value}u"
         is Byte,
         is Short,
         is Int,
@@ -46,6 +50,19 @@ fun Char?.deepPrint(indent: Int = 0): String =
 fun Float?.deepPrint(indent: Int = 0): String =
     if (this == null) "${indent.indent()}null" else "${indent.indent()}${formatForJS()}f"
 
+/*
+ * The unsigned types print with the `u` suffix so the output is assignable back to a
+ * UInt rather than being read as an Int.
+ */
+
+fun UByte?.deepPrint(indent: Int = 0): String = "${indent.indent()}${this?.let { "${it}u" } ?: "null"}"
+
+fun UShort?.deepPrint(indent: Int = 0): String = "${indent.indent()}${this?.let { "${it}u" } ?: "null"}"
+
+fun UInt?.deepPrint(indent: Int = 0): String = "${indent.indent()}${this?.let { "${it}u" } ?: "null"}"
+
+fun ULong?.deepPrint(indent: Int = 0): String = "${indent.indent()}${this?.let { "${it}u" } ?: "null"}"
+
 fun Int.indent(): String = " ".repeat(this)
 
 fun <K, V> Map<K, V>.deepPrint(
@@ -80,6 +97,18 @@ private inline fun <T> Iterable<T>.deepPrintItems(transform: (T) -> String): Str
 
 fun <T> List<T>.deepPrintContents(): String = deepPrintItems { deepPrintPrimitive(it) }
 
+/**
+ * Covers `Collection` and `Iterable` properties. `List` and `Set` have their own, more
+ * specific, overloads and are unaffected.
+ */
+fun <T> Iterable<T>.deepPrintContents(): String = deepPrintItems { deepPrintPrimitive(it) }
+
+/**
+ * Note that this consumes the sequence. A sequence that can only be iterated once is
+ * spent by printing it.
+ */
+fun <T> Sequence<T>.deepPrintContents(): String = asIterable().deepPrintItems { deepPrintPrimitive(it) }
+
 fun <T> Set<T>.deepPrintContents(): String = deepPrintItems { deepPrintPrimitive(it) }
 
 fun <T> Array<T>.deepPrintContents(): String = asIterable().deepPrintItems { deepPrintPrimitive(it) }
@@ -105,6 +134,18 @@ fun DoubleArray.deepPrintContents(): String = asIterable().deepPrintItems { it.d
 fun BooleanArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
 
 fun CharArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+@OptIn(ExperimentalUnsignedTypes::class)
+fun UByteArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+@OptIn(ExperimentalUnsignedTypes::class)
+fun UShortArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+@OptIn(ExperimentalUnsignedTypes::class)
+fun UIntArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
+
+@OptIn(ExperimentalUnsignedTypes::class)
+fun ULongArray.deepPrintContents(): String = asIterable().deepPrintItems { it.deepPrint() }
 
 /**
  * In jvm, android, and native platforms, printing 2.0f

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
@@ -56,6 +56,13 @@ class DeepPrintProcessor(
 
         private val PRIMITIVE_TYPES = setOf(
             "String", "Byte", "Short", "Int", "Long", "Boolean", "Char", "Double", "Float",
+            "UByte", "UShort", "UInt", "ULong",
+        )
+
+        /** Component accessors for Pair and Triple, in order. */
+        private val TUPLE_COMPONENTS = mapOf(
+            "Pair" to listOf("first", "second"),
+            "Triple" to listOf("first", "second", "third"),
         )
 
         private val COLLECTION_CONSTRUCTORS = mapOf(
@@ -67,6 +74,10 @@ class DeepPrintProcessor(
             "HashSet" to "hashSetOf",
             "LinkedHashSet" to "linkedSetOf",
             "Array" to "arrayOf",
+            // Read-only supertypes: listOf() is assignable to all of them.
+            "Collection" to "listOf",
+            "Iterable" to "listOf",
+            "Sequence" to "sequenceOf",
         )
 
         private val MAP_CONSTRUCTORS = mapOf(
@@ -89,6 +100,10 @@ class DeepPrintProcessor(
             "DoubleArray" to "doubleArrayOf",
             "BooleanArray" to "booleanArrayOf",
             "CharArray" to "charArrayOf",
+            "UByteArray" to "ubyteArrayOf",
+            "UShortArray" to "ushortArrayOf",
+            "UIntArray" to "uintArrayOf",
+            "ULongArray" to "ulongArrayOf",
         )
     }
     /**
@@ -239,8 +254,77 @@ class DeepPrintProcessor(
                 typeName in COLLECTION_CONSTRUCTORS -> collectionExpression(imports, type, receiver)
                 typeName in PRIMITIVE_ARRAY_CONSTRUCTORS -> primitiveArrayExpression(imports, type, receiver)
                 typeName in MAP_CONSTRUCTORS -> mapExpression(imports, type, receiver)
+                typeName in TUPLE_COMPONENTS -> tupleExpression(imports, type, receiver)
                 else -> enumExpression(type, receiver)
+                    ?: typeAliasExpression(imports, type, receiver, propertyDeclaration)
                     ?: annotatedDataClassExpression(imports, type, receiver, propertyDeclaration)
+            }
+        }
+
+        /**
+         * Renders [accessor] according to its static [type], wrapping the result so that a
+         * nullable value prints the `null` literal instead of dereferencing nothing. The
+         * primitives need no wrapper: their deepPrint() extensions take a nullable
+         * receiver.
+         */
+        private fun nullSafeValueExpression(
+            imports: LinkedHashSet<String>,
+            type: KSType,
+            accessor: String,
+            lambdaParameter: String,
+        ): String? {
+            val isPrimitive = type.declaration.simpleName.asString() in PRIMITIVE_TYPES
+            if (!type.isMarkedNullable || isPrimitive) {
+                return valueExpression(imports, type, receiver = accessor)
+            }
+            val inner = valueExpression(imports, type, receiver = lambdaParameter)
+            return inner?.let { "($accessor?.let { $lambdaParameter -> $it } ?: \"null\")" }
+        }
+
+        /**
+         * Pair and Triple print as constructor calls on one line, eg. `Pair("a", 1)`.
+         * Components are rendered by their own static type, so a Pair of data classes or
+         * of collections works the same way a property of that type would.
+         */
+        private fun tupleExpression(
+            imports: LinkedHashSet<String>,
+            type: KSType,
+            receiver: String,
+        ): String? {
+            val typeName = type.declaration.simpleName.asString()
+            val components = TUPLE_COMPONENTS.getValue(typeName)
+            val rendered = components.mapIndexed { index, component ->
+                val componentType = type.arguments[index].type!!.resolve()
+                nullSafeValueExpression(
+                    imports = imports,
+                    type = componentType,
+                    accessor = "$receiver.$component",
+                    lambdaParameter = component,
+                ) ?: "$receiver.$component.toString()"
+            }
+            return "\"$typeName(\" + ${rendered.joinToString(" + \", \" + ")} + \")\""
+        }
+
+        /**
+         * A typealias has its own declaration, so `IntList` never matches `List` by name.
+         * Resolving it lets the aliased type be rendered normally.
+         *
+         * Only aliases without type arguments are resolved. For a generic alias such as
+         * `typealias Mapping<V> = Map<String, V>`, the underlying type still carries the
+         * unsubstituted parameter, which would produce code referring to a type that does
+         * not exist at the use site.
+         */
+        private fun typeAliasExpression(
+            imports: LinkedHashSet<String>,
+            type: KSType,
+            receiver: String,
+            propertyDeclaration: KSPropertyDeclaration?,
+        ): String? {
+            val alias = type.declaration as? KSTypeAlias
+            return if (alias != null && type.arguments.isEmpty()) {
+                valueExpression(imports, alias.type.resolve(), receiver, propertyDeclaration)
+            } else {
+                null
             }
         }
 
@@ -332,7 +416,11 @@ class DeepPrintProcessor(
             val itemType = type.arguments[0].type!!
             val resolvedItemType = itemType.resolve()
             val itemIsAnnotated = resolvedItemType.declaration.isAnnotationPresent(DeepPrint::class)
-            val itemEnum = enumExpression(resolvedItemType, "item")
+            val inlineItem = if (resolvedItemType.declaration.simpleName.asString() in PRIMITIVE_TYPES) {
+                "item.deepPrint()"
+            } else {
+                enumExpression(resolvedItemType, "item")
+            }
             val collectionConstructor =
                 COLLECTION_CONSTRUCTORS.getValue(type.declaration.simpleName.asString())
 
@@ -342,12 +430,14 @@ class DeepPrintProcessor(
                         "$receiver.joinToString(separator = \"\") " +
                         "{ item -> item.deepPrint(currentIndent = currentIndent + 2 * indentWidth) + \",\\n\" } + " +
                         "(currentIndent + indentWidth).indent() + \")\""
-                // deepPrintContents() renders items from their runtime type, which for an
-                // enum means an unqualified toString(). The item type is known here, so
-                // the items are laid out directly instead, in the same shape.
-                itemEnum != null ->
+                // deepPrintContents() renders items from their runtime type, which loses
+                // information: an enum comes out as an unqualified toString(), a UInt
+                // without its `u`, and on Kotlin/JS a Float, Double or Char is
+                // indistinguishable from a number. The item type is known statically
+                // here, so items are laid out directly instead, in the same shape.
+                inlineItem != null ->
                     "\"$collectionConstructor<${itemType}>(\" + " +
-                        "$receiver.joinToString(separator = \"\") { item -> \" \" + ($itemEnum) + \",\" } + " +
+                        "$receiver.joinToString(separator = \"\") { item -> \" \" + ($inlineItem) + \",\" } + " +
                         "\")\""
                 else ->
                     "\"$collectionConstructor<${itemType}>(\" + $receiver.deepPrintContents() + \")\""

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectPrimitiveArray.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectPrimitiveArray.kt
@@ -179,9 +179,11 @@ fun CharArray.deepPrintCharArrayReflection(
     )
 )
 
+@OptIn(ExperimentalUnsignedTypes::class)
 internal fun Any.isPrimitiveArray(): Boolean = when (this) {
     is ByteArray, is ShortArray, is IntArray, is LongArray,
-    is FloatArray, is DoubleArray, is BooleanArray, is CharArray -> true
+    is FloatArray, is DoubleArray, is BooleanArray, is CharArray,
+    is UByteArray, is UShortArray, is UIntArray, is ULongArray -> true
     else -> false
 }
 
@@ -190,6 +192,7 @@ internal fun Any.isPrimitiveArray(): Boolean = when (this) {
  * eight primitive array types. Used to render a `data class` property, where the only
  * thing known about the value is that it is [Any].
  */
+@OptIn(ExperimentalUnsignedTypes::class)
 internal fun Any.deepPrintPrimitiveArrayReflectionOrNull(
     startingIndent: Int,
     indentSize: Int,
@@ -203,6 +206,10 @@ internal fun Any.deepPrintPrimitiveArrayReflectionOrNull(
         is DoubleArray -> asIterable() to "doubleArrayOf"
         is BooleanArray -> asIterable() to "booleanArrayOf"
         is CharArray -> asIterable() to "charArrayOf"
+        is UByteArray -> asIterable() to "ubyteArrayOf"
+        is UShortArray -> asIterable() to "ushortArrayOf"
+        is UIntArray -> asIterable() to "uintArrayOf"
+        is ULongArray -> asIterable() to "ulongArrayOf"
         else -> return null
     }
     return items.deepPrintPrimitiveItems(

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
@@ -138,7 +138,11 @@ internal fun <T : Any> KClass<T>.isPrimitive(): Boolean {
         Int::class,
         Long::class,
         Float::class,
-        Double::class -> true
+        Double::class,
+        UByte::class,
+        UShort::class,
+        UInt::class,
+        ULong::class -> true
         else -> false
     }
 }
@@ -153,7 +157,11 @@ fun Any.isPrimitive(): Boolean {
         is Int,
         is Long,
         is Float,
-        is Double -> true
+        is Double,
+        is UByte,
+        is UShort,
+        is UInt,
+        is ULong -> true
         else -> false
     }
 }

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectCollectionsTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectCollectionsTest.kt
@@ -228,4 +228,24 @@ class ReflectCollectionsTest {
         val actual = primitiveArraysContainer.deepPrintReflection()
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun `deep print data class with unsigned types`() {
+        val container = UnsignedContainer(
+            int = 3u,
+            long = 4u,
+            ints = uintArrayOf(5u, 6u),
+        )
+        val expected = """
+            UnsignedContainer(
+                int = 3u,
+                long = 4u,
+                ints =  uintArrayOf(
+                    5u,
+                    6u,
+                ),
+            )
+        """.trimIndent()
+        assertEquals(expected, container.deepPrintReflection())
+    }
 }

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
@@ -121,3 +121,9 @@ data class OpaqueContainer(
     val id: Opaque,
     val name: String,
 )
+
+data class UnsignedContainer(
+    val int: UInt,
+    val long: ULong,
+    val ints: UIntArray,
+)

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -154,6 +154,41 @@ data class WithEnums(
     val toDirections: Map<String, List<Direction>>,
 )
 
+typealias IntList = List<Int>
+
+@DeepPrint
+data class WithTuples(
+    val pair: Pair<String, Int>,
+    val triple: Triple<Int, Boolean, Char>,
+    val pairOfClasses: Pair<Surfer, Direction>,
+)
+
+@DeepPrint
+data class WithReadOnlyCollections(
+    val collection: Collection<Int>,
+    val iterable: Iterable<String>,
+    val sequence: Sequence<Int>,
+    val aliased: IntList,
+)
+
+@DeepPrint
+data class WithUnsigned(
+    val byte: UByte,
+    val short: UShort,
+    val int: UInt,
+    val long: ULong,
+    val ints: UIntArray,
+    val longs: ULongArray,
+)
+
+@DeepPrint
+data class WithTypedCollectionItems(
+    val floats: List<Float>,
+    val doubles: List<Double>,
+    val chars: List<Char>,
+    val uints: List<UInt>,
+)
+
 @DeepPrint
 data class WithAMap(
     val id: Long,

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -32,7 +32,11 @@ import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithNullables
 import com.bradyaiello.deepprint.testclasses.WithPrimitiveArrays
+import com.bradyaiello.deepprint.testclasses.WithReadOnlyCollections
+import com.bradyaiello.deepprint.testclasses.WithTuples
 import com.bradyaiello.deepprint.testclasses.WithTypeAliasProperty
+import com.bradyaiello.deepprint.testclasses.WithTypedCollectionItems
+import com.bradyaiello.deepprint.testclasses.WithUnsigned
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 
@@ -203,6 +207,35 @@ val withEnums = WithEnums(
     directions = listOf(Direction.NORTH, Direction.SOUTH),
     bySide = mapOf(Direction.NORTH to "up"),
     toDirections = mapOf("all" to listOf(Direction.NORTH, Direction.SOUTH)),
+)
+
+val withTuples = WithTuples(
+    pair = "a" to 1,
+    triple = Triple(1, true, 'x'),
+    pairOfClasses = surfer to Direction.NORTH,
+)
+
+val withReadOnlyCollections = WithReadOnlyCollections(
+    collection = listOf(1, 2),
+    iterable = listOf("a", "b"),
+    sequence = sequenceOf(3, 4),
+    aliased = listOf(5, 6),
+)
+
+val withUnsigned = WithUnsigned(
+    byte = 1u,
+    short = 2u,
+    int = 3u,
+    long = 4u,
+    ints = uintArrayOf(5u, 6u),
+    longs = ulongArrayOf(7u, 8u),
+)
+
+val withTypedCollectionItems = WithTypedCollectionItems(
+    floats = listOf(1f, 2.5f),
+    doubles = listOf(1.0, 2.5),
+    chars = listOf('a', 'b'),
+    uints = listOf(3u, 4u),
 )
 
 val withAnnotatedProperty = WithAnnotatedProperty(

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -29,7 +29,6 @@ import com.bradyaiello.deepprint.testobjects.withJdkCollections
 import com.bradyaiello.deepprint.testobjects.withNullablesEmpty
 import com.bradyaiello.deepprint.testobjects.withNullablesPopulated
 import com.bradyaiello.deepprint.testobjects.withPrimitiveArrays
-import com.bradyaiello.deepprint.testobjects.withTypeAliasProperty
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -387,20 +386,6 @@ class BasicTest {
         """.trimIndent()
 
         val actual = withJdkCollections.deepPrint()
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun typeAliasPropertyFallsBackToToString() {
-        // A typealias resolves to a KSTypeAlias, not a class declaration, so there is
-        // nothing to deep print. What matters here is that it does not throw.
-        val expected = """
-            WithTypeAliasProperty(
-              person = SamplePersonClass(name=Dave, sampleClass=SampleClass(x=0.5, y=2.6, name=A point)),
-            )
-        """.trimIndent()
-
-        val actual = withTypeAliasProperty.deepPrint()
         assertEquals(expected, actual)
     }
 

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
@@ -1,0 +1,113 @@
+package com.bradyaiello.deepprint
+
+import com.bradyaiello.deepprint.testclasses.deepPrint
+import com.bradyaiello.deepprint.testobjects.withReadOnlyCollections
+import com.bradyaiello.deepprint.testobjects.withTuples
+import com.bradyaiello.deepprint.testobjects.withTypeAliasProperty
+import com.bradyaiello.deepprint.testobjects.withTypedCollectionItems
+import com.bradyaiello.deepprint.testobjects.withUnsigned
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Coverage for the property types DeepPrint knows how to reconstruct, beyond the
+ * primitives and the everyday collections covered in [BasicTest].
+ */
+class TypeSupportTest {
+
+    @Test
+    fun pairAndTriple() {
+        val expected = """
+            WithTuples(
+              pair = Pair("a", 1),
+              triple = Triple(1, true, 'x'),
+              pairOfClasses = Pair(
+                Surfer(
+                  name = "Honolua Blomfield",
+                  surfboard = 
+                    Surfboard(
+                      length = 11.5f,
+                      width = 2.0f,
+                      style = "longboard",
+                    ),
+                ), Direction.NORTH),
+            )
+        """.trimIndent()
+
+        val actual = withTuples.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun readOnlyCollectionTypes() {
+        val expected = """
+            WithReadOnlyCollections(
+              collection = listOf<Int>( 1, 2,),
+              iterable = listOf<String>( "a", "b",),
+              sequence = sequenceOf<Int>( 3, 4,),
+              aliased = listOf<Int>( 5, 6,),
+            )
+        """.trimIndent()
+
+        val actual = withReadOnlyCollections.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun unsignedTypes() {
+        val expected = """
+            WithUnsigned(
+              byte = 1u,
+              short = 2u,
+              int = 3u,
+              long = 4u,
+              ints = uintArrayOf( 5u, 6u,),
+              longs = ulongArrayOf( 7u, 8u,),
+            )
+        """.trimIndent()
+
+        val actual = withUnsigned.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun collectionItemsUseTheirStaticType() {
+        // Kotlin/JS erases Float, Double and Char to numbers at runtime, so identifying
+        // items by their runtime type printed 2.0f as 2 and 'a' as 97. The item type is
+        // known at code generation time, so it is used instead.
+        val expected = """
+            WithTypedCollectionItems(
+              floats = listOf<Float>( 1.0f, 2.5f,),
+              doubles = listOf<Double>( 1.0, 2.5,),
+              chars = listOf<Char>( 'a', 'b',),
+              uints = listOf<UInt>( 3u, 4u,),
+            )
+        """.trimIndent()
+
+        val actual = withTypedCollectionItems.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun typeAliasResolvesToTheAliasedType() {
+        // PersonAlias is a typealias for the annotated SamplePersonClass. The alias is
+        // resolved, so the property deep prints rather than falling back to toString().
+        val expected = """
+            WithTypeAliasProperty(
+              person = 
+                SamplePersonClass(
+                  name = "Dave",
+                  sampleClass = 
+                    SampleClass(
+                      x = 0.5f,
+                      y = 2.6f,
+                      name = "A point",
+                    ),
+                ),
+            )
+        """.trimIndent()
+
+        val actual = withTypeAliasProperty.deepPrint()
+        assertEquals(expected, actual)
+    }
+}

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/BasicTest.kt
@@ -29,7 +29,6 @@ import com.bradyaiello.deepprint.testobjects.withJdkCollections
 import com.bradyaiello.deepprint.testobjects.withNullablesEmpty
 import com.bradyaiello.deepprint.testobjects.withNullablesPopulated
 import com.bradyaiello.deepprint.testobjects.withPrimitiveArrays
-import com.bradyaiello.deepprint.testobjects.withTypeAliasProperty
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -387,20 +386,6 @@ class BasicTest {
         """.trimIndent()
 
         val actual = withJdkCollections.deepPrint()
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun typeAliasPropertyFallsBackToToString() {
-        // A typealias resolves to a KSTypeAlias, not a class declaration, so there is
-        // nothing to deep print. What matters here is that it does not throw.
-        val expected = """
-            WithTypeAliasProperty(
-                person = SamplePersonClass(name=Dave, sampleClass=SampleClass(x=0.5, y=2.6, name=A point)),
-            )
-        """.trimIndent()
-
-        val actual = withTypeAliasProperty.deepPrint()
         assertEquals(expected, actual)
     }
 

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
@@ -1,0 +1,113 @@
+package com.bradyaiello.deepprint
+
+import com.bradyaiello.deepprint.testclasses.deepPrint
+import com.bradyaiello.deepprint.testobjects.withReadOnlyCollections
+import com.bradyaiello.deepprint.testobjects.withTuples
+import com.bradyaiello.deepprint.testobjects.withTypeAliasProperty
+import com.bradyaiello.deepprint.testobjects.withTypedCollectionItems
+import com.bradyaiello.deepprint.testobjects.withUnsigned
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Coverage for the property types DeepPrint knows how to reconstruct, beyond the
+ * primitives and the everyday collections covered in [BasicTest].
+ */
+class TypeSupportTest {
+
+    @Test
+    fun pairAndTriple() {
+        val expected = """
+            WithTuples(
+                pair = Pair("a", 1),
+                triple = Triple(1, true, 'x'),
+                pairOfClasses = Pair(
+                    Surfer(
+                        name = "Honolua Blomfield",
+                        surfboard = 
+                            Surfboard(
+                                length = 11.5f,
+                                width = 2.0f,
+                                style = "longboard",
+                            ),
+                    ), Direction.NORTH),
+            )
+        """.trimIndent()
+
+        val actual = withTuples.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun readOnlyCollectionTypes() {
+        val expected = """
+            WithReadOnlyCollections(
+                collection = listOf<Int>( 1, 2,),
+                iterable = listOf<String>( "a", "b",),
+                sequence = sequenceOf<Int>( 3, 4,),
+                aliased = listOf<Int>( 5, 6,),
+            )
+        """.trimIndent()
+
+        val actual = withReadOnlyCollections.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun unsignedTypes() {
+        val expected = """
+            WithUnsigned(
+                byte = 1u,
+                short = 2u,
+                int = 3u,
+                long = 4u,
+                ints = uintArrayOf( 5u, 6u,),
+                longs = ulongArrayOf( 7u, 8u,),
+            )
+        """.trimIndent()
+
+        val actual = withUnsigned.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun collectionItemsUseTheirStaticType() {
+        // Kotlin/JS erases Float, Double and Char to numbers at runtime, so identifying
+        // items by their runtime type printed 2.0f as 2 and 'a' as 97. The item type is
+        // known at code generation time, so it is used instead.
+        val expected = """
+            WithTypedCollectionItems(
+                floats = listOf<Float>( 1.0f, 2.5f,),
+                doubles = listOf<Double>( 1.0, 2.5,),
+                chars = listOf<Char>( 'a', 'b',),
+                uints = listOf<UInt>( 3u, 4u,),
+            )
+        """.trimIndent()
+
+        val actual = withTypedCollectionItems.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun typeAliasResolvesToTheAliasedType() {
+        // PersonAlias is a typealias for the annotated SamplePersonClass. The alias is
+        // resolved, so the property deep prints rather than falling back to toString().
+        val expected = """
+            WithTypeAliasProperty(
+                person = 
+                    SamplePersonClass(
+                        name = "Dave",
+                        sampleClass = 
+                            SampleClass(
+                                x = 0.5f,
+                                y = 2.6f,
+                                name = "A point",
+                            ),
+                    ),
+            )
+        """.trimIndent()
+
+        val actual = withTypeAliasProperty.deepPrint()
+        assertEquals(expected, actual)
+    }
+}

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -153,6 +153,41 @@ data class WithEnums(
     val toDirections: Map<String, List<Direction>>,
 )
 
+typealias IntList = List<Int>
+
+@DeepPrint
+data class WithTuples(
+    val pair: Pair<String, Int>,
+    val triple: Triple<Int, Boolean, Char>,
+    val pairOfClasses: Pair<Surfer, Direction>,
+)
+
+@DeepPrint
+data class WithReadOnlyCollections(
+    val collection: Collection<Int>,
+    val iterable: Iterable<String>,
+    val sequence: Sequence<Int>,
+    val aliased: IntList,
+)
+
+@DeepPrint
+data class WithUnsigned(
+    val byte: UByte,
+    val short: UShort,
+    val int: UInt,
+    val long: ULong,
+    val ints: UIntArray,
+    val longs: ULongArray,
+)
+
+@DeepPrint
+data class WithTypedCollectionItems(
+    val floats: List<Float>,
+    val doubles: List<Double>,
+    val chars: List<Char>,
+    val uints: List<UInt>,
+)
+
 @DeepPrint
 data class WithAMap(
     val id: Long,

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -32,7 +32,11 @@ import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithNullables
 import com.bradyaiello.deepprint.testclasses.WithPrimitiveArrays
+import com.bradyaiello.deepprint.testclasses.WithReadOnlyCollections
+import com.bradyaiello.deepprint.testclasses.WithTuples
 import com.bradyaiello.deepprint.testclasses.WithTypeAliasProperty
+import com.bradyaiello.deepprint.testclasses.WithTypedCollectionItems
+import com.bradyaiello.deepprint.testclasses.WithUnsigned
 import com.bradyaiello.deepprint.testclasses.otherpackage.Surfboard
 import com.bradyaiello.deepprint.testclasses.otherpackage.Temperature
 
@@ -203,6 +207,35 @@ val withEnums = WithEnums(
     directions = listOf(Direction.NORTH, Direction.SOUTH),
     bySide = mapOf(Direction.NORTH to "up"),
     toDirections = mapOf("all" to listOf(Direction.NORTH, Direction.SOUTH)),
+)
+
+val withTuples = WithTuples(
+    pair = "a" to 1,
+    triple = Triple(1, true, 'x'),
+    pairOfClasses = surfer to Direction.NORTH,
+)
+
+val withReadOnlyCollections = WithReadOnlyCollections(
+    collection = listOf(1, 2),
+    iterable = listOf("a", "b"),
+    sequence = sequenceOf(3, 4),
+    aliased = listOf(5, 6),
+)
+
+val withUnsigned = WithUnsigned(
+    byte = 1u,
+    short = 2u,
+    int = 3u,
+    long = 4u,
+    ints = uintArrayOf(5u, 6u),
+    longs = ulongArrayOf(7u, 8u),
+)
+
+val withTypedCollectionItems = WithTypedCollectionItems(
+    floats = listOf(1f, 2.5f),
+    doubles = listOf(1.0, 2.5),
+    chars = listOf('a', 'b'),
+    uints = listOf(3u, 4u),
 )
 
 val withAnnotatedProperty = WithAnnotatedProperty(


### PR DESCRIPTION
The four remaining "prints something that isn't valid Kotlin" gaps.

| Property type | Printed as |
| --- | --- |
| `Pair<A, B>`, `Triple<A, B, C>` | `Pair(a, b)`, `Triple(a, b, c)` |
| `Collection<T>`, `Iterable<T>` | `listOf<T>(...)` |
| `Sequence<T>` | `sequenceOf<T>(...)` |
| `UByte`, `UShort`, `UInt`, `ULong` | `3u` |
| `UByteArray` … `ULongArray` | `ubyteArrayOf(...)` … `ulongArrayOf(...)` |
| `typealias` without type arguments | resolved, then rendered as the aliased type |

Tuple components are rendered by their own static type, so a `Pair` of data classes or of collections works the way a property of that type would, and a nullable component prints `null` rather than dereferencing nothing.

Generic aliases are deliberately left alone — `typealias Mapping<V> = Map<String, V>` resolves to a type still carrying the unsubstituted `V`, which would generate code referring to a type that doesn't exist at the use site. That's the only typealias entry left under *Current Limitations*.

## A Kotlin/JS bug fixed on the way

`List<UInt>` needed collection items laid out from their **static** type instead of going through `deepPrintContents()`, which identifies them at runtime. That also closes the JS limitation this README has carried since the primitive arrays went in — JS erases `Float`, `Double` and `Char` to numbers, so the runtime check picked the wrong branch:

```
floats = listOf<Float>( 2, ...)     // 2.0f printed as 2
chars  = listOf<Char>( 97, ...)     // 'a' printed as 97
```

`jsNodeTest` covers it now and the limitation is gone from the README. Output on every other platform is byte-identical.

## Reflection

Unsigned types there too, for parity — `UInt` printed as `3` rather than `3u`, and `UIntArray` as `UIntArray(storage=[5])`. `Pair` and `Triple` already worked in reflection, since they're data classes.

## One test changed meaning

The typealias test added in #27 pinned the old `toString()` fallback. It asserts the resolved behaviour now — which is exactly what having it there was for.

## Tests

`BasicTest` outgrew detekt's `LargeClass` threshold, so type coverage moved to a new `TypeSupportTest` in both projects. Five cases: tuples, read-only collection types, unsigned types, statically-typed collection items, and typealias resolution.

33 KSP tests pass on `jvmTest`, `jsNodeTest`, `macosArm64Test` and `watchosSimulatorArm64Test`; reflection is at 34; `detekt` is clean.

## What's left

Nested collections — `List<List<Int>>` — is the last gap on the list, and the only one with real design content.