### PR TITLE
Support nested collections in both implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,15 +512,16 @@ That is not true for single source projects, like [test-project](./test-project)
 - For KSP, for the entire printed object to be a valid constructor call, all classes in the hierarchy must be annotated.
 - For KSP, if an annotated data class has a property of a non-annotated class, the property's value is printed with a 
   standard `toString()`.
-- Not all collection types are supported. See
+- Not every type is supported. See
   [KSP and Collection Types](#KSP-and-Collection-Types) for what KSP handles, and
   [Reflection and Collection Types](#Reflection-and-Collection-Types) for reflection.
   Still missing, in both implementations:
-    A collection as a *map value*, eg. `Map<String, List<Int>>`, does work.
   - A *generic* `typealias`, eg. `typealias Mapping<V> = Map<String, V>`. The aliased
     type still carries the unsubstituted parameter, so it is left alone and falls back
     to `toString()`. A typealias without type arguments is resolved and printed
     normally.
+  - Printing a `Sequence` consumes it. A sequence that can only be iterated once is
+    spent by being printed.
 - For reflection, a property that is neither a primitive, a supported collection, nor a
   `data class` is printed with `toString()`. Enums are the exception and print
   qualified, eg. `day = DayOfWeek.MONDAY`, which is valid Kotlin as long as the enum is

--- a/README.md
+++ b/README.md
@@ -279,6 +279,29 @@ WithEnums(
 An enum nested in another class prints with its own simple name, eg. `Color.RED` for
 `Outer.Color`, so `import com.example.Outer.Color` is what makes that output compile.
 
+### Nested Collections
+
+Collections nest, in both implementations. A collection can be an item of another
+collection, a map key, or a map value:
+
+```kotlin
+WithNestedMaps(
+    mapOfMaps = mapOf<String,Map<String, Int>>(
+        "a" to mapOf<String,Int>(
+            "b" to 1,
+        ),
+    ),
+    listKeyed = mapOf<List<Int>,String>(
+        listOf<Int>( 1, 2,) to "x",
+    ),
+)
+```
+
+Collections of primitives stay on one line whatever the depth, so
+`List<List<List<Int>>>` prints as
+`listOf<List<List<Int>>>( listOf<List<Int>>( listOf<Int>( 1,),),)`. A map, or a
+collection of annotated `data class`es, opens a block and is indented to its depth.
+
 ### KSP and the Remaining Types
 
 `Pair` and `Triple` print as constructor calls on one line, with each component
@@ -493,8 +516,6 @@ That is not true for single source projects, like [test-project](./test-project)
   [KSP and Collection Types](#KSP-and-Collection-Types) for what KSP handles, and
   [Reflection and Collection Types](#Reflection-and-Collection-Types) for reflection.
   Still missing, in both implementations:
-  - Nested collections, eg. `List<List<Int>>`. The outer collection prints correctly,
-    but the inner one prints via `toString()` as `[0, 1]`, which is not valid Kotlin.
     A collection as a *map value*, eg. `Map<String, List<Int>>`, does work.
   - A *generic* `typealias`, eg. `typealias Mapping<V> = Map<String, V>`. The aliased
     type still carries the unsubstituted parameter, so it is left alone and falls back

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
@@ -54,6 +54,10 @@ class DeepPrintProcessor(
     companion object {
         private const val DATACLASS_MAP_VAL_INDENT_MULTIPLIER = 3
 
+        /** Indent levels, relative to the property, for a block that a value opens. */
+        private const val ENTRY_INDENT_MULTIPLIER = 2
+        private const val CLOSING_INDENT_MULTIPLIER = 1
+
         private val PRIMITIVE_TYPES = setOf(
             "String", "Byte", "Short", "Int", "Long", "Boolean", "Char", "Double", "Float",
             "UByte", "UShort", "UInt", "ULong",
@@ -247,19 +251,25 @@ class DeepPrintProcessor(
             type: KSType,
             receiver: String,
             propertyDeclaration: KSPropertyDeclaration? = null,
+            depth: Int = 0,
         ): String? {
             val typeName = type.declaration.simpleName.asString()
             return when {
                 typeName in PRIMITIVE_TYPES -> "$receiver.deepPrint()"
-                typeName in COLLECTION_CONSTRUCTORS -> collectionExpression(imports, type, receiver)
+                typeName in COLLECTION_CONSTRUCTORS -> collectionExpression(imports, type, receiver, depth)
                 typeName in PRIMITIVE_ARRAY_CONSTRUCTORS -> primitiveArrayExpression(imports, type, receiver)
-                typeName in MAP_CONSTRUCTORS -> mapExpression(imports, type, receiver)
-                typeName in TUPLE_COMPONENTS -> tupleExpression(imports, type, receiver)
+                typeName in MAP_CONSTRUCTORS -> mapExpression(imports, type, receiver, depth)
+                typeName in TUPLE_COMPONENTS -> tupleExpression(imports, type, receiver, depth)
                 else -> enumExpression(type, receiver)
-                    ?: typeAliasExpression(imports, type, receiver, propertyDeclaration)
+                    ?: typeAliasExpression(imports, type, receiver, propertyDeclaration, depth)
                     ?: annotatedDataClassExpression(imports, type, receiver, propertyDeclaration)
             }
         }
+
+        /** True when [type] deep prints, ie. it opens a nested constructor block. */
+        @OptIn(KspExperimental::class)
+        private fun isAnnotatedDataClass(type: KSType): Boolean =
+            type.declaration.isAnnotationPresent(DeepPrint::class)
 
         /**
          * Renders [accessor] according to its static [type], wrapping the result so that a
@@ -272,12 +282,13 @@ class DeepPrintProcessor(
             type: KSType,
             accessor: String,
             lambdaParameter: String,
+            depth: Int = 0,
         ): String? {
             val isPrimitive = type.declaration.simpleName.asString() in PRIMITIVE_TYPES
             if (!type.isMarkedNullable || isPrimitive) {
-                return valueExpression(imports, type, receiver = accessor)
+                return valueExpression(imports, type, receiver = accessor, depth = depth)
             }
-            val inner = valueExpression(imports, type, receiver = lambdaParameter)
+            val inner = valueExpression(imports, type, receiver = lambdaParameter, depth = depth)
             return inner?.let { "($accessor?.let { $lambdaParameter -> $it } ?: \"null\")" }
         }
 
@@ -290,6 +301,7 @@ class DeepPrintProcessor(
             imports: LinkedHashSet<String>,
             type: KSType,
             receiver: String,
+            depth: Int,
         ): String? {
             val typeName = type.declaration.simpleName.asString()
             val components = TUPLE_COMPONENTS.getValue(typeName)
@@ -299,7 +311,8 @@ class DeepPrintProcessor(
                     imports = imports,
                     type = componentType,
                     accessor = "$receiver.$component",
-                    lambdaParameter = component,
+                    lambdaParameter = "$component$depth",
+                    depth = depth + 1,
                 ) ?: "$receiver.$component.toString()"
             }
             return "\"$typeName(\" + ${rendered.joinToString(" + \", \" + ")} + \")\""
@@ -319,10 +332,11 @@ class DeepPrintProcessor(
             type: KSType,
             receiver: String,
             propertyDeclaration: KSPropertyDeclaration?,
+            depth: Int,
         ): String? {
             val alias = type.declaration as? KSTypeAlias
             return if (alias != null && type.arguments.isEmpty()) {
-                valueExpression(imports, alias.type.resolve(), receiver, propertyDeclaration)
+                valueExpression(imports, alias.type.resolve(), receiver, propertyDeclaration, depth)
             } else {
                 null
             }
@@ -373,31 +387,53 @@ class DeepPrintProcessor(
             imports: LinkedHashSet<String>,
             type: KSType,
             receiver: String,
+            depth: Int,
         ): String {
             imports.add("import com.bradyaiello.deepprint.deepPrintContents")
             val ksKeyTypeRef: KSTypeReference = type.arguments[0].type!!
             val ksValueTypeRef: KSTypeReference = type.arguments[1].type!!
+            val keyType = ksKeyTypeRef.resolve()
             val valueType = ksValueTypeRef.resolve()
             val mapConstructor = MAP_CONSTRUCTORS.getValue(type.declaration.simpleName.asString())
-            // A primitive key has deepPrint(); an enum key does not, and used to generate
-            // code that did not compile.
-            val keyTransform = enumExpression(ksKeyTypeRef.resolve(), "key") ?: "key.deepPrint()"
+            val key = "key$depth"
+            val value = "value$depth"
+
+            // An annotated data class key keeps deepPrint(), which prints it inline. Every
+            // other key is rendered from its static type: a primitive has deepPrint(), an
+            // enum and a collection do not, and used to generate code that did not compile.
+            val keyTransform = if (isAnnotatedDataClass(keyType)) {
+                "$key.deepPrint()"
+            } else {
+                nullSafeValueExpression(
+                    imports = imports,
+                    type = keyType,
+                    accessor = key,
+                    lambdaParameter = "nestedKey$depth",
+                    depth = depth + 1,
+                ) ?: "$key.deepPrint()"
+            }
 
             val valueTransform = if (valueType.declaration.isDeepPrintAnnotatedDataClass()) {
                 // A data class value opens a block, so it sits a level deeper than a
                 // value that prints inline next to its key.
-                "\"\\n\" + it.deepPrint(currentIndent + $DATACLASS_MAP_VAL_INDENT_MULTIPLIER * indentWidth)"
+                "\"\\n\" + " +
+                    "$value.deepPrint(currentIndent + ${DATACLASS_MAP_VAL_INDENT_MULTIPLIER + depth} * indentWidth)"
             } else {
-                // Anything else -- including a collection, which has no deepPrint() of
-                // its own and used to generate code that did not compile.
-                valueExpression(imports, valueType, receiver = "it") ?: "it.toString()"
+                nullSafeValueExpression(
+                    imports = imports,
+                    type = valueType,
+                    accessor = value,
+                    lambdaParameter = "nestedValue$depth",
+                    depth = depth + 1,
+                ) ?: "$value.toString()"
             }
 
             return "\"$mapConstructor<$ksKeyTypeRef,$ksValueTypeRef>(\\n\" + " +
                 "$receiver.deepPrintContents(\n" +
-                "keyTransform = { key -> (currentIndent + 2 * indentWidth).indent() + ($keyTransform) },\n" +
-                "valueTransform = { $valueTransform }) + " +
-                "(currentIndent + indentWidth).indent() + \")\""
+                "keyTransform = { $key -> " +
+                "(currentIndent + ${ENTRY_INDENT_MULTIPLIER + depth} * indentWidth).indent() + ($keyTransform) },\n" +
+                "valueTransform = { $value -> $valueTransform }) + " +
+                "(currentIndent + ${CLOSING_INDENT_MULTIPLIER + depth} * indentWidth).indent() + \")\""
         }
 
         /**
@@ -411,36 +447,45 @@ class DeepPrintProcessor(
             imports: LinkedHashSet<String>,
             type: KSType,
             receiver: String,
+            depth: Int,
         ): String {
             imports.add("import com.bradyaiello.deepprint.deepPrintContents")
             val itemType = type.arguments[0].type!!
             val resolvedItemType = itemType.resolve()
-            val itemIsAnnotated = resolvedItemType.declaration.isAnnotationPresent(DeepPrint::class)
-            val inlineItem = if (resolvedItemType.declaration.simpleName.asString() in PRIMITIVE_TYPES) {
-                "item.deepPrint()"
-            } else {
-                enumExpression(resolvedItemType, "item")
-            }
             val collectionConstructor =
                 COLLECTION_CONSTRUCTORS.getValue(type.declaration.simpleName.asString())
+            // Nested collections each open their own lambda, so the parameter names have
+            // to differ or the inner one shadows the outer.
+            val item = "item$depth"
 
-            return when {
-                itemIsAnnotated ->
-                    "\"$collectionConstructor<${itemType}>(\\n\" + " +
-                        "$receiver.joinToString(separator = \"\") " +
-                        "{ item -> item.deepPrint(currentIndent = currentIndent + 2 * indentWidth) + \",\\n\" } + " +
-                        "(currentIndent + indentWidth).indent() + \")\""
-                // deepPrintContents() renders items from their runtime type, which loses
-                // information: an enum comes out as an unqualified toString(), a UInt
-                // without its `u`, and on Kotlin/JS a Float, Double or Char is
-                // indistinguishable from a number. The item type is known statically
-                // here, so items are laid out directly instead, in the same shape.
-                inlineItem != null ->
-                    "\"$collectionConstructor<${itemType}>(\" + " +
-                        "$receiver.joinToString(separator = \"\") { item -> \" \" + ($inlineItem) + \",\" } + " +
-                        "\")\""
-                else ->
-                    "\"$collectionConstructor<${itemType}>(\" + $receiver.deepPrintContents() + \")\""
+            // An annotated data class opens a block, so those items go one per line.
+            if (isAnnotatedDataClass(resolvedItemType)) {
+                return "\"$collectionConstructor<${itemType}>(\\n\" + " +
+                    "$receiver.joinToString(separator = \"\") " +
+                    "{ $item -> $item.deepPrint(" +
+                    "currentIndent = currentIndent + ${ENTRY_INDENT_MULTIPLIER + depth} * indentWidth" +
+                    ") + \",\\n\" } + " +
+                    "(currentIndent + ${CLOSING_INDENT_MULTIPLIER + depth} * indentWidth).indent() + \")\""
+            }
+
+            // deepPrintContents() renders items from their runtime type, which loses
+            // information: an enum comes out as an unqualified toString(), a UInt without
+            // its `u`, a nested collection as `[0, 1]`, and on Kotlin/JS a Float, Double
+            // or Char is indistinguishable from a number. The item type is known
+            // statically here, so items are rendered from it instead.
+            val renderedItem = nullSafeValueExpression(
+                imports = imports,
+                type = resolvedItemType,
+                accessor = item,
+                lambdaParameter = "nested$depth",
+                depth = depth + 1,
+            )
+            return if (renderedItem != null) {
+                "\"$collectionConstructor<${itemType}>(\" + " +
+                    "$receiver.joinToString(separator = \"\") { $item -> \" \" + ($renderedItem) + \",\" } + " +
+                    "\")\""
+            } else {
+                "\"$collectionConstructor<${itemType}>(\" + $receiver.deepPrintContents() + \")\""
             }
         }
 

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectList.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectList.kt
@@ -70,10 +70,14 @@ internal fun <Any> Any?.deepPrintListItem(
 ) {
     val totalIndent = startingIndent.indent() + indentSize.indent()
 
+    val nested = this?.deepPrintNestedCollectionOrNull(startingIndent + indentSize, indentSize)
+
     if (this == null) {
         stringBuilder.append("${totalIndent}null,\n")
     } else if (this::class.isPrimitive()) {
         stringBuilder.append("${totalIndent}${deepPrintPrimitive(this)},\n")
+    } else if (nested != null) {
+        stringBuilder.append("$nested,\n")
     } else if (!this::class.isData) {
         stringBuilder.append("${totalIndent}${this.deepPrintUnsupportedReflection()},\n")
     } else {

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectMap.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectMap.kt
@@ -76,10 +76,14 @@ private fun <Any> Any?.deepPrintMapKeyOrValue(
 ) {
     val totalIndent = startingIndent.indent() + indentSize.indent()
 
+    val nested = this?.deepPrintNestedCollectionOrNull(startingIndent + indentSize, indentSize)
+
     if (this == null) {
         stringBuilder.append("${totalIndent}null")
     } else if (this::class.isPrimitive()) {
         stringBuilder.append("${totalIndent}${deepPrintPrimitive(this)}")
+    } else if (nested != null) {
+        stringBuilder.append(nested)
     } else if (!this::class.isData) {
         stringBuilder.append("${totalIndent}${this.deepPrintUnsupportedReflection()}")
     } else {
@@ -112,6 +116,10 @@ private fun <K, V> Map.Entry<K, V?>.deepPrintMapEntryReflection(
         startingIndent = newStartingIndent,
         indentSize = newIndentSize
     )
-    val suffix = if (singleLine) ",\n" else "\n"
-    stringBuilder.append(suffix)
+    // A nested data class ends with its own comma; a collection literal and an inline
+    // value do not. Asking rather than assuming keeps every entry comma-terminated.
+    if (!stringBuilder.endsWith(",")) {
+        stringBuilder.append(",")
+    }
+    stringBuilder.append("\n")
 }

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectPrimitiveArray.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/ReflectPrimitiveArray.kt
@@ -196,6 +196,7 @@ internal fun Any.isPrimitiveArray(): Boolean = when (this) {
 internal fun Any.deepPrintPrimitiveArrayReflectionOrNull(
     startingIndent: Int,
     indentSize: Int,
+    standalone: Boolean = false,
 ): String? {
     val (items, constructor) = when (this) {
         is ByteArray -> asIterable() to "byteArrayOf"
@@ -217,7 +218,7 @@ internal fun Any.deepPrintPrimitiveArrayReflectionOrNull(
             startingIndent = startingIndent,
             indentSize = indentSize,
             constructor = constructor,
-            standalone = false,
+            standalone = standalone,
         )
     )
 }

--- a/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
+++ b/deep-print-reflection/src/main/java/com/bradyaiello/deepprint/Reflection.kt
@@ -112,6 +112,23 @@ internal fun Any?.printsInline(): Boolean = when {
     else -> !this::class.isData
 }
 
+/**
+ * Renders [this] as a collection literal indented to [startingIndent], or returns null
+ * when it is not a collection. Used where a collection appears inside another
+ * collection or a map: those positions know nothing about the element type, so the
+ * recursion has to be driven from the runtime value.
+ */
+internal fun Any.deepPrintNestedCollectionOrNull(
+    startingIndent: Int,
+    indentSize: Int,
+): String? = when (this) {
+    is List<*> -> deepPrintListReflection(startingIndent, indentSize, "mutableListOf", standalone = true)
+    is Set<*> -> deepPrintSetReflection(startingIndent, indentSize, "mutableSetOf", standalone = true)
+    is Map<*, *> -> deepPrintMapReflection(startingIndent, indentSize, "mutableMapOf", standalone = true)
+    is Array<*> -> deepPrintArrayReflection(startingIndent, indentSize, "arrayOf", standalone = true)
+    else -> deepPrintPrimitiveArrayReflectionOrNull(startingIndent, indentSize, standalone = true)
+}
+
 internal fun Any.deepPrintUnsupportedReflection(): String = when (this) {
     is Enum<*> -> {
         // An enum constant with a body is an anonymous subclass of the enum itself.

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectCollectionsTest.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/ReflectCollectionsTest.kt
@@ -248,4 +248,50 @@ class ReflectCollectionsTest {
         """.trimIndent()
         assertEquals(expected, container.deepPrintReflection())
     }
+
+    @Test
+    fun `deep print data class with nested collections`() {
+        val container = NestedContainer(
+            listOfLists = listOf(listOf(0, 1)),
+            listOfArrays = listOf(intArrayOf(1, 2)),
+            mapValueList = mapOf("a" to listOf(1, 2)),
+            mapOfMaps = mapOf("a" to mapOf("b" to 1)),
+            setOfLists = setOf(listOf(9)),
+        )
+        val expected = """
+            NestedContainer(
+                listOfLists =  mutableListOf(
+                    mutableListOf(
+                        0,
+                        1,
+                    ),
+                ),
+                listOfArrays =  mutableListOf(
+                    intArrayOf(
+                        1,
+                        2,
+                    ),
+                ),
+                mapValueList =  mutableMapOf(
+                    "a" to
+                        mutableListOf(
+                            1,
+                            2,
+                        ),
+                ),
+                mapOfMaps =  mutableMapOf(
+                    "a" to
+                        mutableMapOf(
+                            "b" to 1,
+                        ),
+                ),
+                setOfLists =  mutableSetOf(
+                    mutableListOf(
+                        9,
+                    ),
+                ),
+            )
+        """.trimIndent()
+        assertEquals(expected, container.deepPrintReflection())
+    }
 }

--- a/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
+++ b/deep-print-reflection/src/test/kotlin/com/bradyaiello/deepprint/TestClasses.kt
@@ -127,3 +127,11 @@ data class UnsignedContainer(
     val long: ULong,
     val ints: UIntArray,
 )
+
+data class NestedContainer(
+    val listOfLists: List<List<Int>>,
+    val listOfArrays: List<IntArray>,
+    val mapValueList: Map<String, List<Int>>,
+    val mapOfMaps: Map<String, Map<String, Int>>,
+    val setOfLists: Set<List<Int>>,
+)

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -190,6 +190,21 @@ data class WithTypedCollectionItems(
 )
 
 @DeepPrint
+data class WithNestedCollections(
+    val listOfLists: List<List<Int>>,
+    val setOfLists: Set<List<Int>>,
+    val listOfArrays: List<IntArray>,
+    val deep: List<List<List<Int>>>,
+)
+
+@DeepPrint
+data class WithNestedMaps(
+    val mapOfMaps: Map<String, Map<String, Int>>,
+    val listKeyed: Map<List<Int>, String>,
+    val listOfMaps: List<Map<String, Int>>,
+)
+
+@DeepPrint
 data class WithAMap(
     val id: Long,
     val someMap: Map<Int, String>

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -30,6 +30,8 @@ import com.bradyaiello.deepprint.testclasses.WithEnums
 import com.bradyaiello.deepprint.testclasses.WithJdkCollections
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
+import com.bradyaiello.deepprint.testclasses.WithNestedCollections
+import com.bradyaiello.deepprint.testclasses.WithNestedMaps
 import com.bradyaiello.deepprint.testclasses.WithNullables
 import com.bradyaiello.deepprint.testclasses.WithPrimitiveArrays
 import com.bradyaiello.deepprint.testclasses.WithReadOnlyCollections
@@ -236,6 +238,19 @@ val withTypedCollectionItems = WithTypedCollectionItems(
     doubles = listOf(1.0, 2.5),
     chars = listOf('a', 'b'),
     uints = listOf(3u, 4u),
+)
+
+val withNestedCollections = WithNestedCollections(
+    listOfLists = listOf(listOf(0, 1), listOf(2)),
+    setOfLists = setOf(listOf(1, 2)),
+    listOfArrays = listOf(intArrayOf(1, 2)),
+    deep = listOf(listOf(listOf(1))),
+)
+
+val withNestedMaps = WithNestedMaps(
+    mapOfMaps = mapOf("a" to mapOf("b" to 1)),
+    listKeyed = mapOf(listOf(1, 2) to "x"),
+    listOfMaps = listOf(mapOf("a" to 1)),
 )
 
 val withAnnotatedProperty = WithAnnotatedProperty(

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
@@ -1,6 +1,8 @@
 package com.bradyaiello.deepprint
 
 import com.bradyaiello.deepprint.testclasses.deepPrint
+import com.bradyaiello.deepprint.testobjects.withNestedCollections
+import com.bradyaiello.deepprint.testobjects.withNestedMaps
 import com.bradyaiello.deepprint.testobjects.withReadOnlyCollections
 import com.bradyaiello.deepprint.testobjects.withTuples
 import com.bradyaiello.deepprint.testobjects.withTypeAliasProperty
@@ -108,6 +110,43 @@ class TypeSupportTest {
         """.trimIndent()
 
         val actual = withTypeAliasProperty.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun nestedCollections() {
+        val expected = """
+            WithNestedCollections(
+              listOfLists = listOf<List<Int>>( listOf<Int>( 0, 1,), listOf<Int>( 2,),),
+              setOfLists = setOf<List<Int>>( listOf<Int>( 1, 2,),),
+              listOfArrays = listOf<IntArray>( intArrayOf( 1, 2,),),
+              deep = listOf<List<List<Int>>>( listOf<List<Int>>( listOf<Int>( 1,),),),
+            )
+        """.trimIndent()
+
+        val actual = withNestedCollections.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun nestedMaps() {
+        val expected = """
+            WithNestedMaps(
+              mapOfMaps = mapOf<String,Map<String, Int>>(
+                "a" to mapOf<String,Int>(
+                  "b" to 1,
+                ),
+              ),
+              listKeyed = mapOf<List<Int>,String>(
+                listOf<Int>( 1, 2,) to "x",
+              ),
+              listOfMaps = listOf<Map<String, Int>>( mapOf<String,Int>(
+                  "a" to 1,
+                ),),
+            )
+        """.trimIndent()
+
+        val actual = withNestedMaps.deepPrint()
         assertEquals(expected, actual)
     }
 }

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
@@ -1,6 +1,8 @@
 package com.bradyaiello.deepprint
 
 import com.bradyaiello.deepprint.testclasses.deepPrint
+import com.bradyaiello.deepprint.testobjects.withNestedCollections
+import com.bradyaiello.deepprint.testobjects.withNestedMaps
 import com.bradyaiello.deepprint.testobjects.withReadOnlyCollections
 import com.bradyaiello.deepprint.testobjects.withTuples
 import com.bradyaiello.deepprint.testobjects.withTypeAliasProperty
@@ -108,6 +110,43 @@ class TypeSupportTest {
         """.trimIndent()
 
         val actual = withTypeAliasProperty.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun nestedCollections() {
+        val expected = """
+            WithNestedCollections(
+                listOfLists = listOf<List<Int>>( listOf<Int>( 0, 1,), listOf<Int>( 2,),),
+                setOfLists = setOf<List<Int>>( listOf<Int>( 1, 2,),),
+                listOfArrays = listOf<IntArray>( intArrayOf( 1, 2,),),
+                deep = listOf<List<List<Int>>>( listOf<List<Int>>( listOf<Int>( 1,),),),
+            )
+        """.trimIndent()
+
+        val actual = withNestedCollections.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun nestedMaps() {
+        val expected = """
+            WithNestedMaps(
+                mapOfMaps = mapOf<String,Map<String, Int>>(
+                    "a" to mapOf<String,Int>(
+                        "b" to 1,
+                    ),
+                ),
+                listKeyed = mapOf<List<Int>,String>(
+                    listOf<Int>( 1, 2,) to "x",
+                ),
+                listOfMaps = listOf<Map<String, Int>>( mapOf<String,Int>(
+                        "a" to 1,
+                    ),),
+            )
+        """.trimIndent()
+
+        val actual = withNestedMaps.deepPrint()
         assertEquals(expected, actual)
     }
 }

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -189,6 +189,21 @@ data class WithTypedCollectionItems(
 )
 
 @DeepPrint
+data class WithNestedCollections(
+    val listOfLists: List<List<Int>>,
+    val setOfLists: Set<List<Int>>,
+    val listOfArrays: List<IntArray>,
+    val deep: List<List<List<Int>>>,
+)
+
+@DeepPrint
+data class WithNestedMaps(
+    val mapOfMaps: Map<String, Map<String, Int>>,
+    val listKeyed: Map<List<Int>, String>,
+    val listOfMaps: List<Map<String, Int>>,
+)
+
+@DeepPrint
 data class WithAMap(
     val id: Long,
     val someMap: Map<Int, String>

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -30,6 +30,8 @@ import com.bradyaiello.deepprint.testclasses.WithEnums
 import com.bradyaiello.deepprint.testclasses.WithJdkCollections
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
+import com.bradyaiello.deepprint.testclasses.WithNestedCollections
+import com.bradyaiello.deepprint.testclasses.WithNestedMaps
 import com.bradyaiello.deepprint.testclasses.WithNullables
 import com.bradyaiello.deepprint.testclasses.WithPrimitiveArrays
 import com.bradyaiello.deepprint.testclasses.WithReadOnlyCollections
@@ -236,6 +238,19 @@ val withTypedCollectionItems = WithTypedCollectionItems(
     doubles = listOf(1.0, 2.5),
     chars = listOf('a', 'b'),
     uints = listOf(3u, 4u),
+)
+
+val withNestedCollections = WithNestedCollections(
+    listOfLists = listOf(listOf(0, 1), listOf(2)),
+    setOfLists = setOf(listOf(1, 2)),
+    listOfArrays = listOf(intArrayOf(1, 2)),
+    deep = listOf(listOf(listOf(1))),
+)
+
+val withNestedMaps = WithNestedMaps(
+    mapOfMaps = mapOf("a" to mapOf("b" to 1)),
+    listKeyed = mapOf(listOf(1, 2) to "x"),
+    listOfMaps = listOf(mapOf("a" to 1)),
 )
 
 val withAnnotatedProperty = WithAnnotatedProperty(


### PR DESCRIPTION
The last gap on the list. A collection nested inside another collection printed via `toString()`, and a collection used as a map key didn't compile at all.

| Shape | Before | After |
|---|---|---|
| `List<List<Int>>` | `listOf<List<Int>>( [0, 1], [2],)` | `listOf<List<Int>>( listOf<Int>( 0, 1,), listOf<Int>( 2,),)` |
| `Set<List<Int>>` | `setOf<List<Int>>( [1, 2],)` | `setOf<List<Int>>( listOf<Int>( 1, 2,),)` |
| `List<Map<String, Int>>` | `listOf<Map<String, Int>>( {a=1},)` | a real `mapOf(...)` |
| `List<IntArray>` | `listOf<IntArray>( [I@2b91004a,)` | `listOf<IntArray>( intArrayOf( 1, 2,),)` |
| `Map<List<Int>, String>` | **didn't compile** | `listOf<Int>( 1, 2,) to "x",` |
| `Map<String, Map<String, Int>>` | valid, but misaligned | correctly nested |

Both implementations reach nested values through a position that knows nothing about the element type, and both are fixed by giving that position the renderer the top level already uses.

## KSP

Collection items and map keys go through `valueExpression()` instead of `deepPrintContents()` and `key.deepPrint()`. Since that recurses, nesting works to any depth and in any combination — `List<List<List<Int>>>` included.

Three things that came out of it:

- **Lambda parameters are named by depth** — `item0`, `item1`, `item2`. Nesting means nested lambdas, and reusing `item` would shadow and warn in generated code.
- **Indentation is now depth-relative.** Map and data-class-collection indentation was hardcoded to one and two levels below the property, which is only right at the top level — hence the misaligned map-in-map. At depth 0 the output is byte-identical to before.
- **An annotated data class key keeps `key.deepPrint()`**, which prints inline. Routing it through `valueExpression()` would add a newline in a position that doesn't want one.

## Reflection

`List`/`Set`/`Array` items and map keys/values recurse through a shared `deepPrintNestedCollectionOrNull()` rather than falling through to the `toString()` fallback from #29.

That needed one fix alongside it: the trailing comma on a map entry was decided by whether the entry was single-line, on the assumption that a multi-line value is always a data class — which appends its own comma. A collection value doesn't, so entries silently lost their comma. The suffix asks whether one is already present now.

## Layout

Collections of primitives stay on one line at any depth. A map, or a collection of annotated data classes, opens a block and indents to its depth. A map nested inside an inline collection is valid but reads a little oddly — that's the one cosmetic wrinkle left, and it's noted rather than fixed.

## Tests

Two new KSP cases (`nestedCollections`, `nestedMaps`) in both test projects, and one reflection case covering lists of lists, lists of primitive arrays, a map with list values, a map of maps, and a set of lists.

35 KSP tests pass on `jvmTest`, `jsNodeTest`, `macosArm64Test` and `watchosSimulatorArm64Test`; reflection is at 35; `detekt` is clean.

With this, every gap from the list is closed. What remains under *Current Limitations* is deliberate: generic typealiases (the substitution isn't available), and `Sequence` being consumed by printing it.