### PR TITLE
KSP: resolve generic typealiases

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,15 @@ int = 3u,
 ints = uintArrayOf( 5u, 6u,),
 ```
 
-A `typealias` without type arguments is resolved, so `typealias IntList = List<Int>`
-prints as a list, and an alias for an annotated `data class` deep prints rather than
-falling back to `toString()`.
+A `typealias` is resolved, so `typealias IntList = List<Int>` prints as a list, and an
+alias for an annotated `data class` deep prints rather than falling back to
+`toString()`. Generic aliases resolve too, with the arguments from the use site
+substituted in by name rather than by position:
+
+```kotlin
+typealias Mapping<V> = Map<String, V>   // the parameter is not the first argument
+typealias Grid<T> = List<List<T>>       // the parameter is nested
+```
 
 `Sequence` is supported, but note that printing one **consumes it**. A sequence that
 can only be iterated once is spent by printing it.
@@ -516,10 +522,6 @@ That is not true for single source projects, like [test-project](./test-project)
   [KSP and Collection Types](#KSP-and-Collection-Types) for what KSP handles, and
   [Reflection and Collection Types](#Reflection-and-Collection-Types) for reflection.
   Still missing, in both implementations:
-  - A *generic* `typealias`, eg. `typealias Mapping<V> = Map<String, V>`. The aliased
-    type still carries the unsubstituted parameter, so it is left alone and falls back
-    to `toString()`. A typealias without type arguments is resolved and printed
-    normally.
   - Printing a `Sequence` consumes it. A sequence that can only be iterated once is
     spent by being printed.
 - For reflection, a property that is neither a primitive, a supported collection, nor a

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
@@ -34,6 +34,7 @@ import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.Variance
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSValueArgument
 import com.google.devtools.ksp.symbol.KSValueParameter
@@ -118,7 +119,11 @@ class DeepPrintProcessor(
      */
     private val writtenFiles = mutableSetOf<String>()
 
+    /** Set at the start of each round; needed to build substituted type arguments. */
+    private lateinit var resolver: Resolver
+
     override fun process(resolver: Resolver): List<KSAnnotated> {
+        this.resolver = resolver
         val symbols = resolver.getSymbolsWithAnnotation(DeepPrint::class.qualifiedName!!)
         if (!symbols.iterator().hasNext()) return emptyList()
         symbols.forEach { declaration ->
@@ -334,12 +339,41 @@ class DeepPrintProcessor(
             propertyDeclaration: KSPropertyDeclaration?,
             depth: Int,
         ): String? {
-            val alias = type.declaration as? KSTypeAlias
-            return if (alias != null && type.arguments.isEmpty()) {
-                valueExpression(imports, alias.type.resolve(), receiver, propertyDeclaration, depth)
-            } else {
-                null
+            val alias = type.declaration as? KSTypeAlias ?: return null
+            val substitution = alias.typeParameters
+                .map { it.name.asString() }
+                .zip(type.arguments)
+                .toMap()
+            val underlying = substitute(alias.type.resolve(), substitution)
+            return valueExpression(imports, underlying, receiver, propertyDeclaration, depth)
+        }
+
+        /**
+         * Replaces type parameter references in [type] with the arguments supplied at the
+         * use site, so that `typealias Mapping<V> = Map<String, V>` used as `Mapping<Int>`
+         * resolves to `Map<String, Int>` rather than to `Map<String, V>`.
+         *
+         * The mapping is by name, not by position: an alias parameter can appear anywhere
+         * in the aliased type, or more than once, or not at all.
+         */
+        private fun substitute(type: KSType, substitution: Map<String, KSTypeArgument>): KSType {
+            if (substitution.isEmpty() || type.arguments.isEmpty()) {
+                return type
             }
+            val substituted = type.arguments.map { argument ->
+                val argumentType = argument.type?.resolve()
+                val parameterName = (argumentType?.declaration as? KSTypeParameter)?.name?.asString()
+                when {
+                    parameterName != null -> substitution[parameterName] ?: argument
+                    argumentType == null || argumentType.arguments.isEmpty() -> argument
+                    // A parameter nested inside the aliased type, eg. List<List<T>>.
+                    else -> resolver.getTypeArgument(
+                        resolver.createKSTypeReferenceFromKSType(substitute(argumentType, substitution)),
+                        argument.variance.takeUnless { it == Variance.STAR } ?: Variance.INVARIANT,
+                    )
+                }
+            }
+            return type.replace(substituted)
         }
 
         /**

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -204,6 +204,15 @@ data class WithNestedMaps(
     val listOfMaps: List<Map<String, Int>>,
 )
 
+typealias Mapping<V> = Map<String, V>
+typealias Grid<T> = List<List<T>>
+
+@DeepPrint
+data class WithGenericAliases(
+    val mapping: Mapping<Int>,
+    val grid: Grid<Int>,
+)
+
 @DeepPrint
 data class WithAMap(
     val id: Long,

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -27,6 +27,7 @@ import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableSet
 import com.bradyaiello.deepprint.testclasses.WithEnums
+import com.bradyaiello.deepprint.testclasses.WithGenericAliases
 import com.bradyaiello.deepprint.testclasses.WithJdkCollections
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
@@ -251,6 +252,11 @@ val withNestedMaps = WithNestedMaps(
     mapOfMaps = mapOf("a" to mapOf("b" to 1)),
     listKeyed = mapOf(listOf(1, 2) to "x"),
     listOfMaps = listOf(mapOf("a" to 1)),
+)
+
+val withGenericAliases = WithGenericAliases(
+    mapping = mapOf("a" to 1),
+    grid = listOf(listOf(1, 2)),
 )
 
 val withAnnotatedProperty = WithAnnotatedProperty(

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
@@ -1,6 +1,7 @@
 package com.bradyaiello.deepprint
 
 import com.bradyaiello.deepprint.testclasses.deepPrint
+import com.bradyaiello.deepprint.testobjects.withGenericAliases
 import com.bradyaiello.deepprint.testobjects.withNestedCollections
 import com.bradyaiello.deepprint.testobjects.withNestedMaps
 import com.bradyaiello.deepprint.testobjects.withReadOnlyCollections
@@ -147,6 +148,23 @@ class TypeSupportTest {
         """.trimIndent()
 
         val actual = withNestedMaps.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun genericTypeAliasesResolve() {
+        // Mapping<V> = Map<String, V> puts the parameter in the second position, and
+        // Grid<T> = List<List<T>> nests it, so neither substitutes positionally.
+        val expected = """
+            WithGenericAliases(
+              mapping = mapOf<String,Int>(
+                "a" to 1,
+              ),
+              grid = listOf<List<Int>>( listOf<Int>( 1, 2,),),
+            )
+        """.trimIndent()
+
+        val actual = withGenericAliases.deepPrint()
         assertEquals(expected, actual)
     }
 }

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
@@ -1,6 +1,7 @@
 package com.bradyaiello.deepprint
 
 import com.bradyaiello.deepprint.testclasses.deepPrint
+import com.bradyaiello.deepprint.testobjects.withGenericAliases
 import com.bradyaiello.deepprint.testobjects.withNestedCollections
 import com.bradyaiello.deepprint.testobjects.withNestedMaps
 import com.bradyaiello.deepprint.testobjects.withReadOnlyCollections
@@ -147,6 +148,23 @@ class TypeSupportTest {
         """.trimIndent()
 
         val actual = withNestedMaps.deepPrint()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun genericTypeAliasesResolve() {
+        // Mapping<V> = Map<String, V> puts the parameter in the second position, and
+        // Grid<T> = List<List<T>> nests it, so neither substitutes positionally.
+        val expected = """
+            WithGenericAliases(
+                mapping = mapOf<String,Int>(
+                    "a" to 1,
+                ),
+                grid = listOf<List<Int>>( listOf<Int>( 1, 2,),),
+            )
+        """.trimIndent()
+
+        val actual = withGenericAliases.deepPrint()
         assertEquals(expected, actual)
     }
 }

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -203,6 +203,15 @@ data class WithNestedMaps(
     val listOfMaps: List<Map<String, Int>>,
 )
 
+typealias Mapping<V> = Map<String, V>
+typealias Grid<T> = List<List<T>>
+
+@DeepPrint
+data class WithGenericAliases(
+    val mapping: Mapping<Int>,
+    val grid: Grid<Int>,
+)
+
 @DeepPrint
 data class WithAMap(
     val id: Long,

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -27,6 +27,7 @@ import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableList
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableMutableSet
 import com.bradyaiello.deepprint.testclasses.WithDeepPrintableSet
 import com.bradyaiello.deepprint.testclasses.WithEnums
+import com.bradyaiello.deepprint.testclasses.WithGenericAliases
 import com.bradyaiello.deepprint.testclasses.WithJdkCollections
 import com.bradyaiello.deepprint.testclasses.WithMapDataClasses
 import com.bradyaiello.deepprint.testclasses.WithMutableMapDataClasses
@@ -251,6 +252,11 @@ val withNestedMaps = WithNestedMaps(
     mapOfMaps = mapOf("a" to mapOf("b" to 1)),
     listKeyed = mapOf(listOf(1, 2) to "x"),
     listOfMaps = listOf(mapOf("a" to 1)),
+)
+
+val withGenericAliases = WithGenericAliases(
+    mapping = mapOf("a" to 1),
+    grid = listOf(listOf(1, 2)),
 )
 
 val withAnnotatedProperty = WithAnnotatedProperty(


### PR DESCRIPTION
One of the two remaining limitations turns out to be solvable.

A typealias with type arguments was left unresolved on the grounds that the aliased type carries the alias's *own* type parameters rather than the arguments from the use site — `Mapping<Int>` resolves to `Map<String, V>`, not `Map<String, Int>`, so rendering it would generate code referring to a `V` that doesn't exist where you paste it.

The fix is to substitute the parameters by name, walking the aliased type. **By name rather than by position**, because an alias parameter can appear anywhere in the aliased type, more than once, or not at all:

```kotlin
typealias Mapping<V> = Map<String, V>   // the parameter is the second argument
typealias Grid<T> = List<List<T>>       // the parameter is nested one level down
```

Both print properly now:

```kotlin
WithGenericAliases(
    mapping = mapOf<String,Int>(
        "a" to 1,
    ),
    grid = listOf<List<Int>>( listOf<Int>( 1, 2,),),
)
```

Substituting a *nested* parameter means building a new `KSTypeArgument`, which needs the `Resolver`, so the processor keeps the one it's handed for the round.

## Reflection

No equivalent — typealiases are erased at runtime, so reflection never sees one to resolve. KSP-only by nature, not by omission.

## Tests

One new case in `TypeSupportTest` in both projects, deliberately using an alias whose parameter is *not* in the first position and one where it's nested — a positional substitution would pass a naive test and fail both of these.

36 KSP tests pass on `jvmTest`, `jsNodeTest`, `macosArm64Test` and `watchosSimulatorArm64Test`; reflection is at 35; `detekt` is clean.

## What this leaves

`Sequence` is the only limitation left, and unlike this one it is not fixable — it needs a decision rather than a patch. Details in the conversation; happy to open a follow-up either way.