### PR TITLE
Drop Sequence support: printing one destroys it

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,6 @@ A property whose type is one of these is printed as the call that rebuilds it:
 | `HashMap<K, V>` | `hashMapOf<K, V>(...)` |
 | `LinkedHashMap<K, V>` | `linkedMapOf<K, V>(...)` |
 | `Collection<T>`, `Iterable<T>` | `listOf<T>(...)` |
-| `Sequence<T>` | `sequenceOf<T>(...)` |
 | `UByteArray`, `UShortArray`, `UIntArray`, `ULongArray` | `ubyteArrayOf(...)`, `ushortArrayOf(...)`, `uintArrayOf(...)`, `ulongArrayOf(...)` |
 | `Pair<A, B>`, `Triple<A, B, C>` | `Pair(a, b)`, `Triple(a, b, c)` |
 | `ByteArray`, `ShortArray`, `IntArray`, `LongArray` | `byteArrayOf(...)`, `shortArrayOf(...)`, `intArrayOf(...)`, `longArrayOf(...)` |
@@ -329,9 +328,6 @@ substituted in by name rather than by position:
 typealias Mapping<V> = Map<String, V>   // the parameter is not the first argument
 typealias Grid<T> = List<List<T>>       // the parameter is nested
 ```
-
-`Sequence` is supported, but note that printing one **consumes it**. A sequence that
-can only be iterated once is spent by printing it.
 
 ### KSP and Nullable Properties
 
@@ -518,12 +514,14 @@ That is not true for single source projects, like [test-project](./test-project)
 - For KSP, for the entire printed object to be a valid constructor call, all classes in the hierarchy must be annotated.
 - For KSP, if an annotated data class has a property of a non-annotated class, the property's value is printed with a 
   standard `toString()`.
+- A `Sequence` property is not reconstructed; it prints with `toString()`. Printing one
+  would have to iterate it, which consumes a single-use sequence and exhausts the heap
+  on an infinite one. `Collection` and `Iterable` are supported, on the assumption that
+  they can be iterated more than once.
 - Not every type is supported. See
   [KSP and Collection Types](#KSP-and-Collection-Types) for what KSP handles, and
   [Reflection and Collection Types](#Reflection-and-Collection-Types) for reflection.
   Still missing, in both implementations:
-  - Printing a `Sequence` consumes it. A sequence that can only be iterated once is
-    spent by being printed.
 - For reflection, a property that is neither a primitive, a supported collection, nor a
   `data class` is printed with `toString()`. Enums are the exception and print
   qualified, eg. `day = DayOfWeek.MONDAY`, which is valid Kotlin as long as the enum is

--- a/README.md
+++ b/README.md
@@ -521,7 +521,6 @@ That is not true for single source projects, like [test-project](./test-project)
 - Not every type is supported. See
   [KSP and Collection Types](#KSP-and-Collection-Types) for what KSP handles, and
   [Reflection and Collection Types](#Reflection-and-Collection-Types) for reflection.
-  Still missing, in both implementations:
 - For reflection, a property that is neither a primitive, a supported collection, nor a
   `data class` is printed with `toString()`. Enums are the exception and print
   qualified, eg. `day = DayOfWeek.MONDAY`, which is valid Kotlin as long as the enum is

--- a/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
+++ b/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/Utils.kt
@@ -103,11 +103,6 @@ fun <T> List<T>.deepPrintContents(): String = deepPrintItems { deepPrintPrimitiv
  */
 fun <T> Iterable<T>.deepPrintContents(): String = deepPrintItems { deepPrintPrimitive(it) }
 
-/**
- * Note that this consumes the sequence. A sequence that can only be iterated once is
- * spent by printing it.
- */
-fun <T> Sequence<T>.deepPrintContents(): String = asIterable().deepPrintItems { deepPrintPrimitive(it) }
 
 fun <T> Set<T>.deepPrintContents(): String = deepPrintItems { deepPrintPrimitive(it) }
 

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
@@ -79,10 +79,15 @@ class DeepPrintProcessor(
             "HashSet" to "hashSetOf",
             "LinkedHashSet" to "linkedSetOf",
             "Array" to "arrayOf",
-            // Read-only supertypes: listOf() is assignable to all of them.
+            // Read-only supertypes: listOf() is assignable to both.
+            //
+            // Sequence is deliberately absent. Printing one has to iterate it, which
+            // consumes a single-use sequence and never returns for an infinite one. A
+            // debugging aid should not be able to destroy what it is inspecting, so a
+            // Sequence property falls back to toString() like any other type DeepPrint
+            // cannot reconstruct.
             "Collection" to "listOf",
             "Iterable" to "listOf",
-            "Sequence" to "sequenceOf",
         )
 
         private val MAP_CONSTRUCTORS = mapOf(

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -167,7 +167,6 @@ data class WithTuples(
 data class WithReadOnlyCollections(
     val collection: Collection<Int>,
     val iterable: Iterable<String>,
-    val sequence: Sequence<Int>,
     val aliased: IntList,
 )
 
@@ -212,6 +211,9 @@ data class WithGenericAliases(
     val mapping: Mapping<Int>,
     val grid: Grid<Int>,
 )
+
+@DeepPrint
+data class WithASequence(val name: String, val sequence: Sequence<Int>)
 
 @DeepPrint
 data class WithAMap(

--- a/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project-multiplatform/src/commonMain/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -221,7 +221,6 @@ val withTuples = WithTuples(
 val withReadOnlyCollections = WithReadOnlyCollections(
     collection = listOf(1, 2),
     iterable = listOf("a", "b"),
-    sequence = sequenceOf(3, 4),
     aliased = listOf(5, 6),
 )
 

--- a/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
+++ b/test-project-multiplatform/src/commonTest/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
@@ -1,5 +1,6 @@
 package com.bradyaiello.deepprint
 
+import com.bradyaiello.deepprint.testclasses.WithASequence
 import com.bradyaiello.deepprint.testclasses.deepPrint
 import com.bradyaiello.deepprint.testobjects.withGenericAliases
 import com.bradyaiello.deepprint.testobjects.withNestedCollections
@@ -11,6 +12,7 @@ import com.bradyaiello.deepprint.testobjects.withTypedCollectionItems
 import com.bradyaiello.deepprint.testobjects.withUnsigned
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Coverage for the property types DeepPrint knows how to reconstruct, beyond the
@@ -47,7 +49,6 @@ class TypeSupportTest {
             WithReadOnlyCollections(
               collection = listOf<Int>( 1, 2,),
               iterable = listOf<String>( "a", "b",),
-              sequence = sequenceOf<Int>( 3, 4,),
               aliased = listOf<Int>( 5, 6,),
             )
         """.trimIndent()
@@ -166,5 +167,17 @@ class TypeSupportTest {
 
         val actual = withGenericAliases.deepPrint()
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun sequencePropertyIsNotConsumed() {
+        // A Sequence prints with toString() rather than being reconstructed, precisely
+        // so that printing cannot iterate it. constrainOnce() makes that observable:
+        // if deepPrint() touched the sequence, toList() below would throw.
+        val sequence = sequenceOf(1, 2, 3).constrainOnce()
+        val actual = WithASequence(name = "s", sequence = sequence).deepPrint()
+
+        assertTrue(actual.contains("name = \"s\","))
+        assertEquals(listOf(1, 2, 3), sequence.toList())
     }
 }

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/TypeSupportTest.kt
@@ -1,5 +1,6 @@
 package com.bradyaiello.deepprint
 
+import com.bradyaiello.deepprint.testclasses.WithASequence
 import com.bradyaiello.deepprint.testclasses.deepPrint
 import com.bradyaiello.deepprint.testobjects.withGenericAliases
 import com.bradyaiello.deepprint.testobjects.withNestedCollections
@@ -11,6 +12,7 @@ import com.bradyaiello.deepprint.testobjects.withTypedCollectionItems
 import com.bradyaiello.deepprint.testobjects.withUnsigned
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Coverage for the property types DeepPrint knows how to reconstruct, beyond the
@@ -47,7 +49,6 @@ class TypeSupportTest {
             WithReadOnlyCollections(
                 collection = listOf<Int>( 1, 2,),
                 iterable = listOf<String>( "a", "b",),
-                sequence = sequenceOf<Int>( 3, 4,),
                 aliased = listOf<Int>( 5, 6,),
             )
         """.trimIndent()
@@ -166,5 +167,17 @@ class TypeSupportTest {
 
         val actual = withGenericAliases.deepPrint()
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun sequencePropertyIsNotConsumed() {
+        // A Sequence prints with toString() rather than being reconstructed, precisely
+        // so that printing cannot iterate it. constrainOnce() makes that observable:
+        // if deepPrint() touched the sequence, toList() below would throw.
+        val sequence = sequenceOf(1, 2, 3).constrainOnce()
+        val actual = WithASequence(name = "s", sequence = sequence).deepPrint()
+
+        assertTrue(actual.contains("name = \"s\","))
+        assertEquals(listOf(1, 2, 3), sequence.toList())
     }
 }

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testclasses/SampleClass.kt
@@ -166,7 +166,6 @@ data class WithTuples(
 data class WithReadOnlyCollections(
     val collection: Collection<Int>,
     val iterable: Iterable<String>,
-    val sequence: Sequence<Int>,
     val aliased: IntList,
 )
 
@@ -211,6 +210,9 @@ data class WithGenericAliases(
     val mapping: Mapping<Int>,
     val grid: Grid<Int>,
 )
+
+@DeepPrint
+data class WithASequence(val name: String, val sequence: Sequence<Int>)
 
 @DeepPrint
 data class WithAMap(

--- a/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
+++ b/test-project/src/test/kotlin/com/bradyaiello/deepprint/testobjects/TestObjects.kt
@@ -221,7 +221,6 @@ val withTuples = WithTuples(
 val withReadOnlyCollections = WithReadOnlyCollections(
     collection = listOf(1, 2),
     iterable = listOf("a", "b"),
-    sequence = sequenceOf(3, 4),
     aliased = listOf(5, 6),
 )
 


### PR DESCRIPTION
> **Stacked on #34.** Both edit the same *Current Limitations* block. GitHub retargets this to `main` when #34 merges.

I added `Sequence` support in #32 alongside `Collection` and `Iterable`, without thinking through what iterating one costs. Two failure modes, both reproduced before writing this:

**A single-use sequence is consumed by being printed.**

```kotlin
val s = sequenceOf(1, 2, 3).constrainOnce()
holder.deepPrint()   // succeeds
s.toList()           // IllegalStateException: This sequence can be consumed only once
```

The print silently destroyed the caller's data.

**An infinite sequence throws `OutOfMemoryError`.** `generateSequence(1) { it + 1 }` builds a string until the heap is gone. This one was never documented.

## Why not fix it instead

Neither is fixable. A single-use sequence can't be iterated without being consumed, and a sequence can't be known to be infinite. Capping the element count would produce output that silently isn't the data — worse than refusing, because it looks valid.

And the thing being printed was never faithfully reconstructable anyway: `sequenceOf(1, 2, 3)` is not the lazy computation it was printed from. DeepPrint is a debugging aid — it gets called on live objects, often from a log statement, and a log statement that empties a sequence or takes down the process is a bad trade.

## What changes

A `Sequence` property falls back to `toString()`, like any other type DeepPrint can't reconstruct. `Collection` and `Iterable` stay, on the assumption that they can be iterated more than once — that assumption is now stated in the README rather than implied.

## The test

Pins the property that actually matters rather than the output string:

```kotlin
val sequence = sequenceOf(1, 2, 3).constrainOnce()
WithASequence(name = "s", sequence = sequence).deepPrint()
assertEquals(listOf(1, 2, 3), sequence.toList())   // still usable
```

If `deepPrint()` ever touches a sequence again, that fails in CI rather than in someone's logs.

36 KSP tests pass on `jvmTest`, `jsNodeTest`, `macosArm64Test` and `watchosSimulatorArm64Test`; reflection is at 35; `detekt` is clean.