### PR TITLE
Publish on tags only, not on every push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,10 @@ name: Publish
 
 on:
   workflow_dispatch:
+  # Tags only. Publishing on every push to main meant re-publishing whatever version
+  # gradle.properties happened to hold, which Maven Central rejects as a duplicate, so
+  # every merge produced a failing run. Releasing is a deliberate act: tag it.
   push:
-    branches:
-      - main
     tags:
       - '*'
 


### PR DESCRIPTION
The Publish workflow runs on every push to `main` and has failed every time — ten failing runs in the last few hours, one per merge. (Only ten are visible; GitHub's retention has aged out anything older.)

It can't succeed on a push to `main` **by design**: it publishes whatever version `gradle.properties` holds, and `0.1.0-alpha10` has been on Maven Central since June 2023. A fully working pipeline would be rejected as a duplicate on every merge. The version only changes when someone decides to release — which is what a tag marks.

Existing tags are unprefixed (`0.1.0-alpha10`), so the pattern stays `'*'` rather than `'v*'`. `workflow_dispatch` is unchanged.

## This does not fix publishing

Two other things are broken, both older than this workflow's last change:

- **`SIGNING_KEY_ID` is never passed to the job.** The convention plugin only configures signing when `signing.keyId` is non-null, so no `sign*` tasks are created — while the workaround at the bottom of `kmp.convention.publication.gradle.kts` makes every publish task depend on them unconditionally. That's the error in all ten runs: `Task with name 'signMingwX64Publication' not found`. `git log -p` confirms the secret has never been passed, which fits #15 still being open.
- **It deploys to `s01.oss.sonatype.org`.** OSSRH reached end of life on 30 June 2025. Maven Central publishing goes through the Central Portal now — different endpoint, different API; the staging-repository flow this uses no longer exists.

Both are the subject of the follow-up PR. What this one changes is that a red `main` stops being the normal state, so the next real failure is actually visible.

To be clear about cause: #26 touched this file (JDK 17, `macos-latest`, `actions/*@v4`), but the failures predate it and would happen regardless.