### PR TITLE
Correct the namespace in RELEASING.md, and record how signing fails

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,9 +7,17 @@ DeepPrint publishes to Maven Central through the
 
 ## One-time setup
 
-1. **Claim the namespace.** Sign in to the Central Portal and confirm that
-   `com.bradyaiello` is listed and verified. Namespaces that had published through
-   OSSRH were migrated, so it should already be there.
+1. **Claim the namespace.** Sign in to the Central Portal
+   (<https://central.sonatype.com>, note `.com`; `central.sonatype.org` is the
+   documentation site) and confirm under Publishing Settings that
+   `com.bradyaiello.deepprint` is listed and Verified. That is the whole group id every
+   published module uses, so the namespace has to match it, not the shorter
+   `com.bradyaiello`. Namespaces that had published through OSSRH were migrated, so it
+   should already be there.
+
+   Namespaces are tied to the sign-in method, not the email address. Signing in with
+   GitHub and signing in with Google are separate accounts even for the same person, so
+   if the namespace is missing, try the other method before registering anything.
 2. **Create a user token.** Portal → your account → *Generate User Token*. This gives a
    username and password pair. They are not the account credentials, and they are not
    the old OSSRH ones.
@@ -54,6 +62,27 @@ deployment to the Portal.
    you to check and publish. To have CI release it without that step, change the Gradle
    invocation in `.github/workflows/publish.yml` from `publishToMavenCentral` to
    `publishAndReleaseToMavenCentral`.
+
+## When signing fails
+
+Signing runs before the upload, so a key problem hides any credentials problem behind
+it. The message tells you which of the three secrets is at fault:
+
+| Message | Meaning |
+| --- | --- |
+| `PGPException: checksum mismatch in checksum of 20 bytes` | The key decrypted with the wrong passphrase. `SIGNING_KEY_PASSWORD` does not match `SIGNING_SECRET_KEY`. |
+| `Could not read PGP secret key` | `SIGNING_SECRET_KEY` is not a readable armoured private key -- a public key, a binary export, or truncated. |
+
+Reproduce either locally without going through CI. This runs the same code path:
+
+```bash
+./gradlew :deep-print-annotations:signJvmPublication \
+  -PsigningInMemoryKey="$(gpg --armor --export-secret-keys YOUR_KEY_ID)" \
+  -PsigningInMemoryKeyPassword='your-passphrase'
+```
+
+Also check that the key has not expired. Central rejects signatures from an expired key,
+and a two-year expiry is a common default.
 
 ## Checking it locally
 


### PR DESCRIPTION
Two corrections to the release runbook, both learned since it was written.

## The namespace was wrong

I wrote `com.bradyaiello`. It's **`com.bradyaiello.deepprint`** — that's the group id all three published modules use, and it's what's verified in the Portal:

```
deep-print-annotations   group = "com.bradyaiello.deepprint"
deep-print-processor     group = "com.bradyaiello.deepprint"
deep-print-reflection    group = "com.bradyaiello.deepprint"
```

As written, the runbook would send someone hunting for a namespace that doesn't exist, or registering one they don't need. The group and the namespace do match, so nothing about the build is affected — only the documentation was wrong.

Also noted that namespaces are tied to the **sign-in method**, not the email address — GitHub and Google sign-ins are separate accounts for the same person. The Portal warns about this, and a namespace appearing to be missing is alarming enough to be worth pre-empting.

## How signing fails

The first snapshot attempt failed with:

```
PGPException: checksum mismatch in checksum of 20 bytes
```

That's the **wrong passphrase**, not a malformed key — a malformed key gives `Could not read PGP secret key`. The message names neither the secret nor the passphrase, so both are now in a table with what each means.

Two things that make this worth writing down rather than rediscovering:

- Signing runs **before** the upload, so a key problem hides any credentials problem behind it. You fix one and immediately meet the next.
- The failure is reproducible locally through the same code path, turning a five-minute CI round trip into a few seconds:

```bash
./gradlew :deep-print-annotations:signJvmPublication \
  -PsigningInMemoryKey="$(gpg --armor --export-secret-keys YOUR_KEY_ID)" \
  -PsigningInMemoryKeyPassword='your-passphrase'
```

Plus a note to check the key hasn't expired — Central rejects signatures from expired keys and a two-year default would have lapsed for a 2023 key.

Documentation only; no build or test changes.