### PR TITLE
Release 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The reflection implementation is only for Kotlin on the JVM, but its benefits ar
 If you're using Kotlin on the JVM or Android, just add the dependency:
 
 ```kotlin
-implementation("com.bradyaiello.deepprint:deep-print-reflection:<latest-version>")
+implementation("com.bradyaiello.deepprint:deep-print-reflection:0.2.0")
 ```
 
 Now, calling `deepPrintReflection()` on a `data class` will return a readable `String`
@@ -426,14 +426,14 @@ plugins {
 ```kotlin
 dependencies {
     // @DeepPrint annotation and a few helper functions
-    implementation("com.bradyaiello.deepprint:deep-print-annotations:0.1.0-alpha")
+    implementation("com.bradyaiello.deepprint:deep-print-annotations:0.2.0")
     // Where all the DeepPrint code generation logic resides
-    implementation("com.bradyaiello.deepprint:deep-print-processor:0.1.0-alpha")
+    implementation("com.bradyaiello.deepprint:deep-print-processor:0.2.0")
     // Run the processor over your main source set
-    ksp("com.bradyaiello.deepprint:deep-print-processor:0.1.0-alpha")
+    ksp("com.bradyaiello.deepprint:deep-print-processor:0.2.0")
     // KSP 2 no longer fans `ksp` out to every source set, so annotate-in-tests
     // needs the processor wired up for the test source set too
-    kspTest("com.bradyaiello.deepprint:deep-print-processor:0.1.0-alpha")
+    kspTest("com.bradyaiello.deepprint:deep-print-processor:0.2.0")
 }
 ```
 3. Tell Gradle where to find the KSP-generated code.
@@ -472,7 +472,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("com.bradyaiello.deepprint:deep-print-annotations:0.1.0-alpha")
+                implementation("com.bradyaiello.deepprint:deep-print-annotations:0.2.0")
             }
             kotlin.srcDir(layout.buildDirectory.dir("generated/ksp/metadata/commonMain/kotlin"))
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ kotlin.code.style=official
 org.gradle.parallel=false
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g
 
-version=0.1.0-alpha10
+version=0.2.0
 
 kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
Sets `version=0.2.0` and points the README's dependency snippets at it.

Merge this, and I'll tag `0.2.0` on `main` — which is what actually triggers the Publish workflow.

## Why 0.2.0 and not 1.0.0

The coverage would justify a 1.x — both implementations now handle essentially every collection type, nullables, enums, tuples, unsigned types and arbitrary nesting. But the API surface moved twice in getting here, and `Sequence` support was added and removed within a few hours. 1.0.0 is a promise not to break things; that promise would be a few days old.

## Two changes consumers will notice

- **Reflection prints nested data class properties with their name**: `address = Address(` where it previously emitted a bare `Address(`. The old output wasn't valid Kotlin — a positional argument can't follow named ones — but anyone diffing against golden strings will see changes.
- **`deepPrint()` extensions take nullable receivers.** Source compatible, *not* binary compatible; dependents need recompiling.

Both are worth putting in the GitHub release notes.

## README

The dependency snippets said `0.1.0-alpha` and, for reflection, a `<latest-version>` placeholder. Both now name `0.2.0`.

## What happens after the tag

The workflow builds, signs, and uploads a deployment to the Central Portal. **It does not release it.** Nothing sets `automaticRelease`, so the deployment lands *pending* for you to inspect under Deployments, and nothing is public until you click Publish there. If it looks wrong, drop it.

That review is the real gate — worth checking all 17 publications are present, that `deep-print-annotations` has all 14 targets, and that the POMs carry the licence, developer and scm blocks.

Verified locally: `publishToMavenLocal` produces `0.2.0` for every module and target.

The snapshot dry run already proved signing, the Portal token and the upload path work. The one thing it could *not* prove is validation — Sonatype performs none on snapshots — so a real deployment reaching "validated" is genuinely new information.