### PR TITLE
KSP: generate for every data class, without annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,52 @@ data class SamplePersonClass(val name: String, val sampleClass: SampleClass)
 @DeepPrint
 data class ThreeClassesDeep(val person: SamplePersonClass, val age: Int)
 ```
+## No-Annotation Mode
+
+Annotating every class gets tedious, and the requirement that *every* class in a
+hierarchy be annotated makes it easy to get a half-deep print. Turn that off:
+
+```kotlin
+ksp {
+    arg("processAllDataClasses", "true")
+}
+```
+
+Every `data class` in the source set now gets a `deepPrint()`, with no annotation
+anywhere, and nested `data class` properties print in full rather than falling back to
+`toString()`.
+
+To exclude a class, annotate it — the annotation is now only needed by the exceptions:
+
+```kotlin
+@NoDeepPrint
+data class HugePayload(val bytes: List<Byte>)
+```
+
+Some classes are skipped automatically, because a generated top level extension in
+another file could not reach them:
+
+| Skipped | Why |
+| --- | --- |
+| `private` and local classes | Not visible outside their own file or scope |
+| `protected` nested classes | Not visible outside the class hierarchy |
+
+`internal` classes are included, and their generated function is `internal` too — a
+public extension on an internal receiver does not compile.
+
+Nested classes are qualified, so `Outer.Inner` prints as `Outer.Inner(...)` and the
+generated file is `DeepPrintOuter_Inner.kt` rather than colliding with a top level
+`Inner`.
+
+### Overriding toString()
+
+`arg("overrideToString", "true")` is accepted but currently only emits a warning.
+Replacing `toString()` cannot be done by a symbol processor: KSP adds new files, it
+cannot alter an existing class, and neither an extension nor an interface can supply
+`toString()` — a member always wins over an extension, and Kotlin forbids interfaces
+from implementing `Any`'s methods. Doing it properly needs a Kotlin compiler plugin,
+which is not built yet.
+
 ## KSP Quick Start
 
 ### Add KSP
@@ -511,9 +557,11 @@ That is not true for single source projects, like [test-project](./test-project)
 
 ## Current Limitations
 - DeepPrint only works on `data class`es.
-- For KSP, for the entire printed object to be a valid constructor call, all classes in the hierarchy must be annotated.
-- For KSP, if an annotated data class has a property of a non-annotated class, the property's value is printed with a 
-  standard `toString()`.
+- For KSP, for the entire printed object to be a valid constructor call, all classes in the hierarchy must be annotated,
+  and a property of a non-annotated class is printed with a standard `toString()`. Neither applies in
+  [No-Annotation Mode](#No-Annotation-Mode).
+- For KSP, `overrideToString` does not work yet; it needs a compiler plugin. See
+  [Overriding toString()](#Overriding-toString).
 - A `Sequence` property is not reconstructed; it prints with `toString()`. Printing one
   would have to iterate it, which consumes a single-use sequence and exhausts the heap
   on an infinite one. `Collection` and `Iterable` are supported, on the assumption that

--- a/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/NoDeepPrint.kt
+++ b/deep-print-annotations/src/commonMain/kotlin/com/bradyaiello/deepprint/NoDeepPrint.kt
@@ -1,0 +1,12 @@
+package com.bradyaiello.deepprint
+
+/**
+ * Excludes a `data class` from processing when DeepPrint is generating for every data
+ * class rather than only annotated ones.
+ *
+ * Only needed for the exceptions: a class whose printed form would be unhelpfully large,
+ * or one holding something that should not end up in a log.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class NoDeepPrint()

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessor.kt
@@ -5,9 +5,11 @@ package com.bradyaiello.deepprint
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.getDeclaredProperties
+import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.isAnnotationPresent
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
@@ -40,6 +42,7 @@ import com.google.devtools.ksp.symbol.KSValueArgument
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.Modifier.DATA
+import com.google.devtools.ksp.symbol.Visibility
 import com.google.devtools.ksp.validate
 import java.io.OutputStream
 
@@ -49,7 +52,11 @@ fun OutputStream.appendText(str: String) {
 
 class DeepPrintProcessor(
     val codeGenerator: CodeGenerator,
-    val indent: Int = 4
+    val logger: KSPLogger,
+    val indent: Int = 4,
+    /** Generate for every data class, rather than only those annotated @DeepPrint. */
+    val processAllDataClasses: Boolean = false,
+    val overrideToString: Boolean = false,
 ) : SymbolProcessor {
 
     companion object {
@@ -58,6 +65,13 @@ class DeepPrintProcessor(
         /** Indent levels, relative to the property, for a block that a value opens. */
         private const val ENTRY_INDENT_MULTIPLIER = 2
         private const val CLOSING_INDENT_MULTIPLIER = 1
+
+        /** Visibilities a top level extension in another file cannot reach. */
+        private val UNREACHABLE_VISIBILITIES = setOf(
+            Visibility.PRIVATE,
+            Visibility.PROTECTED,
+            Visibility.LOCAL,
+        )
 
         private val PRIMITIVE_TYPES = setOf(
             "String", "Byte", "Short", "Int", "Long", "Boolean", "Char", "Double", "Float",
@@ -124,12 +138,22 @@ class DeepPrintProcessor(
      */
     private val writtenFiles = mutableSetOf<String>()
 
+    private var warnedAboutOverrideToString = false
+
     /** Set at the start of each round; needed to build substituted type arguments. */
     private lateinit var resolver: Resolver
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         this.resolver = resolver
-        val symbols = resolver.getSymbolsWithAnnotation(DeepPrint::class.qualifiedName!!)
+        if (overrideToString && !warnedAboutOverrideToString) {
+            warnedAboutOverrideToString = true
+            logger.warn(
+                "DeepPrint: overrideToString is set, but replacing toString() cannot be done " +
+                    "by a symbol processor -- KSP only adds new files, it cannot alter an " +
+                    "existing class. deepPrint() is being generated instead. See the README."
+            )
+        }
+        val symbols = symbolsToProcess(resolver)
         if (!symbols.iterator().hasNext()) return emptyList()
         symbols.forEach { declaration ->
             val containingFile = declaration.containingFile
@@ -156,9 +180,70 @@ class DeepPrintProcessor(
         return symbols.filterNot { it.validate() }.toList()
     }
 
+    /**
+     * Either every eligible data class, or only the annotated symbols.
+     *
+     * Walking every declaration reaches classes the annotated path never saw, so this is
+     * where the cases that path never had to handle get filtered out. See [isEligible].
+     */
+    private fun symbolsToProcess(resolver: Resolver): Sequence<KSAnnotated> =
+        if (processAllDataClasses) {
+            resolver.getAllFiles()
+                .flatMap { it.declarations }
+                .flatMap { it.withNestedDeclarations() }
+                .filterIsInstance<KSClassDeclaration>()
+                .filter { it.isEligible() }
+        } else {
+            resolver.getSymbolsWithAnnotation(DeepPrint::class.qualifiedName!!)
+        }
+
+    /** A declaration and, recursively, anything declared inside it. */
+    private fun KSDeclaration.withNestedDeclarations(): Sequence<KSDeclaration> =
+        sequenceOf(this) + when (this) {
+            is KSClassDeclaration -> declarations.flatMap { it.withNestedDeclarations() }
+            else -> emptySequence()
+        }
+
+    @OptIn(KspExperimental::class)
+    private fun KSClassDeclaration.isEligible(): Boolean = when {
+        !modifiers.contains(DATA) -> false
+        isAnnotationPresent(NoDeepPrint::class) -> false
+        // The generated extension lives in a separate file in the same package, so it
+        // cannot reach a private, protected or local class.
+        getVisibility() in UNREACHABLE_VISIBILITIES -> false
+        // Anonymous or otherwise unnameable.
+        qualifiedName == null -> false
+        else -> true
+    }
+
+    /**
+     * How the class is named from inside its own package, so `Outer.Inner` rather than
+     * `Inner`. Both the generated extension's receiver and the constructor call it prints
+     * need this, since a bare `Inner` resolves to nothing at package level.
+     */
+    private fun KSClassDeclaration.receiverName(): String? {
+        val qualified = qualifiedName?.asString() ?: return null
+        val packagePrefix = packageName.asString()
+        return if (packagePrefix.isEmpty()) qualified else qualified.removePrefix("$packagePrefix.")
+    }
+
+    /**
+     * Whether DeepPrint generates a deepPrint() for [declaration], and so whether a
+     * property of that type can be printed as a constructor call rather than toString().
+     * With processAllDataClasses the annotation is no longer what decides this.
+     */
+    @OptIn(KspExperimental::class)
+    private fun generatesDeepPrintFor(declaration: KSDeclaration?): Boolean {
+        val classDeclaration = declaration as? KSClassDeclaration ?: return false
+        return classDeclaration.isEligible() &&
+            (processAllDataClasses || classDeclaration.isAnnotationPresent(DeepPrint::class))
+    }
+
     private fun getFileName(declaration: KSAnnotated): String? { 
         return when (declaration) {
-            is KSClassDeclaration ->  declaration.simpleName.asString()
+            // A nested class carries its outer names, or Outer.Inner and a top level
+            // Inner would both want to write DeepPrintInner.kt.
+            is KSClassDeclaration -> declaration.receiverName()?.replace('.', '_')
             is KSPropertyDeclaration -> declaration.simpleName.asString() 
             else -> null
         }
@@ -171,7 +256,7 @@ class DeepPrintProcessor(
         @OptIn(KspExperimental::class)
         override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit): String {
             val packageName = classDeclaration.containingFile!!.packageName.asString()
-            val className = classDeclaration.simpleName.asString()
+            val className = classDeclaration.receiverName() ?: return ""
             val props = classDeclaration.getDeclaredProperties()
             return visitDeepPrintAnnotated(classDeclaration, packageName, className, props)
         }
@@ -198,7 +283,13 @@ class DeepPrintProcessor(
                 packageStringBuilder.append("package $packageName\n\n")
 
                 functionStringBuilder.append("\n")
-                functionStringBuilder.append("fun ${className}.deepPrint(currentIndent: Int = 0): String {\n")
+                // A public extension on an internal receiver does not compile, so the
+                // generated function matches the visibility of the class it prints.
+                val visibility =
+                    if (classDeclaration.getVisibility() == Visibility.INTERNAL) "internal " else ""
+                functionStringBuilder.append(
+                    "${visibility}fun ${className}.deepPrint(currentIndent: Int = 0): String {\n"
+                )
                 functionStringBuilder.append("val indentWidth = $indent\n")
                 functionStringBuilder.append("return \"\"\"")
 
@@ -279,7 +370,7 @@ class DeepPrintProcessor(
         /** True when [type] deep prints, ie. it opens a nested constructor block. */
         @OptIn(KspExperimental::class)
         private fun isAnnotatedDataClass(type: KSType): Boolean =
-            type.declaration.isAnnotationPresent(DeepPrint::class)
+            generatesDeepPrintFor(type.declaration)
 
         /**
          * Renders [accessor] according to its static [type], wrapping the result so that a
@@ -411,8 +502,8 @@ class DeepPrintProcessor(
             val propClassDeclaration = type.declaration as? KSClassDeclaration ?: return null
             val propPackageName = propClassDeclaration.packageName.asString()
             // TODO(Support properties defined outside of the module)
-            val annotated = propClassDeclaration.isDataClass() &&
-                (propClassDeclaration.isAnnotationPresent(DeepPrint::class) ||
+            val annotated = generatesDeepPrintFor(propClassDeclaration) ||
+                (propClassDeclaration.isDataClass() &&
                     propertyDeclaration?.isAnnotationPresent(DeepPrint::class) == true)
             return if (annotated) {
                 imports.add("import $propPackageName.deepPrint")
@@ -543,9 +634,8 @@ class DeepPrintProcessor(
             return "\"$arrayConstructor(\" + $receiver.deepPrintContents() + \")\""
         }
 
-        private fun KSDeclaration.isDeepPrintAnnotatedDataClass(): Boolean {
-            return isDataClass() && isAnnotationPresent(DeepPrint::class)
-        }
+        private fun KSDeclaration.isDeepPrintAnnotatedDataClass(): Boolean =
+            generatesDeepPrintFor(this)
         
 //        private fun KSClassDeclaration.isDeepPrintAnnotatedDataClass(): Boolean {
 //            return isDataClass() && isAnnotationPresent(DeepPrint::class) 

--- a/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessorProvider.kt
+++ b/deep-print-processor/src/main/kotlin/com/bradyaiello/deepprint/DeepPrintSymbolProcessorProvider.kt
@@ -9,7 +9,11 @@ class DeepPrintSymbolProcessorProvider : SymbolProcessorProvider {
         val indent = (environment.options["indent"] ?: "4").toInt()
         return DeepPrintProcessor(
             codeGenerator = environment.codeGenerator,
+            logger = environment.logger,
             indent = indent,
+            // Generate for every data class rather than only @DeepPrint annotated ones.
+            processAllDataClasses = environment.options["processAllDataClasses"].toBoolean(),
+            overrideToString = environment.options["overrideToString"].toBoolean(),
         )
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ include(
     ":deep-print-reflection",
     ":test-project",
     ":test-project-multiplatform",
+    ":test-project-no-annotations",
     ":external-module",
 )
 

--- a/test-project-no-annotations/build.gradle.kts
+++ b/test-project-no-annotations/build.gradle.kts
@@ -1,0 +1,31 @@
+repositories {
+    google()
+    mavenCentral()
+    mavenLocal()
+}
+
+plugins {
+    kotlin("jvm")
+    id("com.google.devtools.ksp")
+    id("io.gitlab.arturbosch.detekt")
+}
+
+kotlin.sourceSets {
+    test {
+        kotlin.srcDirs(
+            layout.buildDirectory.dir("generated/ksp/test/kotlin"),
+        )
+    }
+}
+
+// The point of this module: no @DeepPrint anywhere in its sources.
+ksp {
+    arg("processAllDataClasses", "true")
+}
+
+dependencies {
+    implementation(project(":deep-print-annotations"))
+    kspTest(project(":deep-print-processor"))
+    testImplementation(project(":deep-print-annotations"))
+    testImplementation(kotlin("test"))
+}

--- a/test-project-no-annotations/src/test/kotlin/com/bradyaiello/deepprint/noannotations/NoAnnotationTest.kt
+++ b/test-project-no-annotations/src/test/kotlin/com/bradyaiello/deepprint/noannotations/NoAnnotationTest.kt
@@ -1,0 +1,72 @@
+package com.bradyaiello.deepprint.noannotations
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Nothing in this module is annotated with @DeepPrint. The processor runs with
+ * processAllDataClasses, so every eligible data class gets a deepPrint().
+ */
+class NoAnnotationTest {
+
+    @Test
+    fun unannotatedClassesDeepPrintIncludingTheirProperties() {
+        // Neither Line nor Point is annotated. Under the annotated mode, start and end
+        // would have fallen back to toString().
+        val expected = """
+            Line(
+                start = 
+                    Point(
+                        x = 1,
+                        y = 2,
+                    ),
+                end = 
+                    Point(
+                        x = 3,
+                        y = 4,
+                    ),
+                label = "a line",
+            )
+        """.trimIndent()
+
+        assertEquals(expected, Line(Point(1, 2), Point(3, 4), "a line").deepPrint())
+    }
+
+    @Test
+    fun nestedClassIsQualified() {
+        // A bare `Inner` would not resolve at package level, in the receiver or in the
+        // printed constructor call.
+        val expected = """
+            Outer.Inner(
+                name = "x",
+            )
+        """.trimIndent()
+
+        assertEquals(expected, Outer.Inner("x").deepPrint())
+    }
+
+    @Test
+    fun noDeepPrintExcludesAClass() {
+        // Excluded gets no deepPrint(), so the property falls back to toString().
+        val expected = """
+            HoldsExcluded(
+                excluded = Excluded(payload=p),
+                id = 7,
+            )
+        """.trimIndent()
+
+        assertEquals(expected, HoldsExcluded(Excluded("p"), 7).deepPrint())
+    }
+
+    @Test
+    fun internalClassesAreIncluded() {
+        // internal is visible across the module, unlike private.
+        val expected = """
+            InternalPoint(
+                x = 5,
+            )
+        """.trimIndent()
+
+        assertEquals(expected, InternalPoint(5).deepPrint())
+    }
+}

--- a/test-project-no-annotations/src/test/kotlin/com/bradyaiello/deepprint/noannotations/TestClasses.kt
+++ b/test-project-no-annotations/src/test/kotlin/com/bradyaiello/deepprint/noannotations/TestClasses.kt
@@ -1,0 +1,29 @@
+package com.bradyaiello.deepprint.noannotations
+
+import com.bradyaiello.deepprint.NoDeepPrint
+
+data class Point(val x: Int, val y: Int)
+
+/** Nothing here is annotated, and the nested Points still deep print. */
+data class Line(val start: Point, val end: Point, val label: String)
+
+class Outer {
+    /** Referencing this as a bare `Inner` would not resolve at package level. */
+    data class Inner(val name: String)
+}
+
+internal data class InternalPoint(val x: Int)
+
+/**
+ * File-private, so a generated extension in a separate file could not see it. This
+ * module compiling at all is the assertion that it was skipped.
+ */
+private data class Secret(val token: String)
+
+@NoDeepPrint
+data class Excluded(val payload: String)
+
+data class HoldsExcluded(val excluded: Excluded, val id: Int)
+
+@Suppress("UnusedPrivateProperty")
+private val keepSecretReferenced = Secret("unused")


### PR DESCRIPTION
```kotlin
ksp { arg("processAllDataClasses", "true") }
```

Every `data class` in the source set gets a `deepPrint()`, no annotation anywhere. `@NoDeepPrint` excludes one — the annotation is only needed by the exceptions now.

It also removes the trap where a hierarchy had to be annotated all the way down or the print quietly stopped being a valid constructor call. "Deep printable" no longer means "annotated", so a property of any eligible data class prints in full.

## Three things that only surface when you process everything

The annotated path never met these, because people annotate public top-level classes. Each one generates code that doesn't compile:

| Case | Problem | Handling |
|---|---|---|
| `private` / local / `protected` classes | A generated extension in another file can't reach them | Skipped |
| Nested classes | A bare `Inner` resolves to nothing at package level | Qualified as `Outer.Inner`, in both the receiver and the printed constructor call. File is `DeepPrintOuter_Inner.kt`, so no collision with a top-level `Inner` |
| `internal` classes | `public member exposes its internal receiver type` | Generated function is `internal` too |

That last one is a compile error, not a warning — a public extension on an internal receiver is illegal, so any project with an internal data class would have failed to build.

## overrideToString

Accepted, and **warns**. Replacing `toString()` can't be done by a symbol processor:

- KSP only adds new files; it can't alter an existing class.
- An extension can't supply it — a member always wins over an extension.
- An interface can't either — Kotlin forbids interfaces from implementing `Any`'s methods.
- Data classes are final, so no generated subclass.

It needs a Kotlin compiler plugin doing IR transformation, which isn't built. I've made it warn rather than silently no-op, since an option that quietly does nothing is the worse failure. The spike for the plugin is next.

## Tests

New module `test-project-no-annotations`, with no `@DeepPrint` in it at all: unannotated nesting, a qualified nested class, `@NoDeepPrint` falling back to `toString()`, and an internal class. That the module compiles is itself the assertion that the private class was skipped.

Existing suites unchanged — 37 KSP across jvm/js/macosArm64/watchosSimulatorArm64, 35 reflection, detekt clean.