### PR TITLE
Spike: compiler plugin rewriting toString() to call deepPrint()

### DIFF
--- a/deep-print-compiler-plugin/build.gradle.kts
+++ b/deep-print-compiler-plugin/build.gradle.kts
@@ -1,0 +1,21 @@
+import de.fayard.refreshVersions.core.versionFor
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+plugins {
+    `java-library`
+    kotlin("jvm")
+    id("io.gitlab.arturbosch.detekt")
+}
+
+val kotlinVersion = versionFor("version.kotlin")
+
+dependencies {
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion")
+}
+
+group = "com.bradyaiello.deepprint"
+version = providers.gradleProperty("version").get()

--- a/deep-print-compiler-plugin/src/main/kotlin/com/bradyaiello/deepprint/compiler/DeepPrintCompilerPluginRegistrar.kt
+++ b/deep-print-compiler-plugin/src/main/kotlin/com/bradyaiello/deepprint/compiler/DeepPrintCompilerPluginRegistrar.kt
@@ -1,0 +1,17 @@
+package com.bradyaiello.deepprint.compiler
+
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+@OptIn(ExperimentalCompilerApi::class)
+class DeepPrintCompilerPluginRegistrar : CompilerPluginRegistrar() {
+    override val pluginId: String = "com.bradyaiello.deepprint"
+
+    override val supportsK2: Boolean = true
+
+    override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+        IrGenerationExtension.registerExtension(DeepPrintIrGenerationExtension())
+    }
+}

--- a/deep-print-compiler-plugin/src/main/kotlin/com/bradyaiello/deepprint/compiler/DeepPrintIrGenerationExtension.kt
+++ b/deep-print-compiler-plugin/src/main/kotlin/com/bradyaiello/deepprint/compiler/DeepPrintIrGenerationExtension.kt
@@ -1,0 +1,88 @@
+package com.bradyaiello.deepprint.compiler
+
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irInt
+import org.jetbrains.kotlin.ir.builders.irReturn
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
+import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+/**
+ * Spike: rewrites the compiler-synthesised toString() of every data class to delegate to
+ * the deepPrint() extension KSP generates for it.
+ *
+ * Delegating rather than building the printed string in IR keeps the version-specific
+ * surface to a single call, and works on every Kotlin target, since deepPrint() is
+ * ordinary Kotlin generated into the same module.
+ */
+class DeepPrintIrGenerationExtension : IrGenerationExtension {
+
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+        moduleFragment.acceptChildrenVoid(object : IrVisitorVoid() {
+            override fun visitElement(element: org.jetbrains.kotlin.ir.IrElement) {
+                element.acceptChildrenVoid(this)
+            }
+
+            override fun visitClass(declaration: IrClass) {
+                if (declaration.isData) {
+                    rewriteToString(declaration, pluginContext)
+                }
+                declaration.acceptChildrenVoid(this)
+            }
+        })
+    }
+
+    private fun rewriteToString(irClass: IrClass, pluginContext: IrPluginContext) {
+        val toStringFunction = irClass.functions.firstOrNull {
+            it.name.asString() == "toString" &&
+                it.parameters.none { parameter -> parameter.kind == IrParameterKind.Regular }
+        }
+        val deepPrint = findDeepPrintFor(irClass, pluginContext)
+        val dispatchReceiver = toStringFunction?.dispatchReceiverParameter
+        if (toStringFunction == null || deepPrint == null || dispatchReceiver == null) {
+            return
+        }
+
+        toStringFunction.body =
+            DeclarationIrBuilder(pluginContext, toStringFunction.symbol).irBlockBody {
+                +irReturn(
+                    irCall(deepPrint).apply {
+                        // Kotlin 2.4 unified the receivers and value arguments into one
+                        // positional list: extension receiver first, then the parameters.
+                        arguments[0] = irGet(dispatchReceiver)
+                        arguments[1] = irInt(0)
+                    }
+                )
+            }
+    }
+
+    /** The generated `fun <ThisClass>.deepPrint(currentIndent: Int = 0): String`. */
+    private fun findDeepPrintFor(
+        irClass: IrClass,
+        pluginContext: IrPluginContext,
+    ): IrSimpleFunction? {
+        val packageName = irClass.kotlinFqName.parent()
+        val candidates = pluginContext.referenceFunctions(
+            CallableId(FqName(packageName.asString()), Name.identifier("deepPrint"))
+        )
+        return candidates.firstOrNull { candidate ->
+            val receiver = candidate.owner.parameters
+                .firstOrNull { parameter -> parameter.kind == IrParameterKind.ExtensionReceiver }
+            receiver?.type == irClass.defaultType
+        }?.owner
+    }
+}

--- a/deep-print-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+++ b/deep-print-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -1,0 +1,1 @@
+com.bradyaiello.deepprint.compiler.DeepPrintCompilerPluginRegistrar

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,9 +18,11 @@ rootProject.name = "deep-print"
 include(
     ":deep-print-annotations",
     ":deep-print-processor",
+    ":deep-print-compiler-plugin",
     ":deep-print-reflection",
     ":test-project",
     ":test-project-multiplatform",
+    ":test-project-tostring",
     ":external-module",
 )
 

--- a/test-project-tostring/build.gradle.kts
+++ b/test-project-tostring/build.gradle.kts
@@ -1,0 +1,39 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+plugins {
+    kotlin("jvm")
+    id("com.google.devtools.ksp")
+    id("io.gitlab.arturbosch.detekt")
+}
+
+kotlin.sourceSets {
+    main {
+        kotlin.srcDirs(layout.buildDirectory.dir("generated/ksp/main/kotlin"))
+    }
+}
+
+// Spike wiring. A real setup would ship a KotlinCompilerPluginSupportPlugin so consumers
+// never see this; passing -Xplugin by hand is enough to find out whether the IR
+// transformation works.
+val deepPrintCompilerPlugin: Configuration by configurations.creating {
+    isTransitive = false
+}
+
+dependencies {
+    implementation(project(":deep-print-annotations"))
+    ksp(project(":deep-print-processor"))
+    deepPrintCompilerPlugin(project(":deep-print-compiler-plugin"))
+    testImplementation(kotlin("test"))
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    // freeCompilerArgs is not the channel for this: the Kotlin compile task has its own
+    // pluginClasspath, which is what KotlinCompilerPluginSupportPlugin feeds in a real
+    // setup.
+    pluginClasspath.from(deepPrintCompilerPlugin)
+}

--- a/test-project-tostring/src/main/kotlin/com/bradyaiello/deepprint/tostring/Classes.kt
+++ b/test-project-tostring/src/main/kotlin/com/bradyaiello/deepprint/tostring/Classes.kt
@@ -1,0 +1,12 @@
+package com.bradyaiello.deepprint.tostring
+
+import com.bradyaiello.deepprint.DeepPrint
+
+// Annotated because this spike branches from main, which does not yet have the
+// no-annotation mode. The IR rewrite being spiked is independent of how deepPrint()
+// comes to exist.
+@DeepPrint
+data class Point(val x: Int, val y: Int)
+
+@DeepPrint
+data class Line(val start: Point, val label: String)

--- a/test-project-tostring/src/test/kotlin/com/bradyaiello/deepprint/tostring/ToStringTest.kt
+++ b/test-project-tostring/src/test/kotlin/com/bradyaiello/deepprint/tostring/ToStringTest.kt
@@ -1,0 +1,45 @@
+package com.bradyaiello.deepprint.tostring
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ToStringTest {
+
+    @Test
+    fun toStringIsReplacedByDeepPrint() {
+        val expected = """
+            Point(
+                x = 1,
+                y = 2,
+            )
+        """.trimIndent()
+
+        assertEquals(expected, Point(1, 2).toString())
+    }
+
+    @Test
+    fun stringInterpolationUsesIt() {
+        // Interpolation calls toString(), so this proves the real member was replaced
+        // rather than something merely resembling it being called explicitly.
+        assertEquals(Point(1, 2).toString(), "${Point(1, 2)}")
+    }
+
+    @Test
+    fun nestedDataClassesPrintDeeply() {
+        val printed = Line(Point(3, 4), "edge").toString()
+
+        assertTrue(printed.startsWith("Line("), printed)
+        assertTrue(printed.contains("x = 3,"), printed)
+        assertTrue(printed.contains("""label = "edge","""), printed)
+    }
+
+    @Test
+    fun collectionsOfDataClassesUseItToo() {
+        // The element's toString() is what a list prints with, so this is where an
+        // overridden toString() becomes very visible.
+        val printed = listOf(Point(1, 2)).toString()
+
+        assertTrue(printed.contains("x = 1,"), printed)
+    }
+}


### PR DESCRIPTION
**Draft, not for merge.** This answers whether overriding `toString()` is tractable and what it would cost.

## It works

```kotlin
assertEquals(expected, Point(1, 2).toString())   // deep printed
assertEquals(Point(1, 2).toString(), "${Point(1, 2)}")  // interpolation too
listOf(Point(1, 2)).toString()                   // and list elements
```

4/4 passing in `test-project-tostring`.

## The design that makes it cheap

Instead of building the printed string in IR — per-property concatenation, one of the most version-exposed things you can write — the plugin **rewrites the synthesised `toString()` to delegate to the `deepPrint()` KSP already generates**. The version-sensitive surface collapses to a single call, and it should carry to every Kotlin target, since `deepPrint()` is ordinary Kotlin compiled into the same module.

## What it cost, which is the point

**Six API breakages in ~70 lines**, from one Kotlin minor-version window — my first attempt used APIs that were correct not long ago:

| Was | Is |
|---|---|
| `IrFunction.valueParameters` | `parameters` + `IrParameterKind` |
| `IrCall.extensionReceiver` | unified positional `arguments[]` |
| `putValueArgument(i, x)` | `arguments[i] = x` |
| `extensionReceiverParameter` | `parameters.first { it.kind == ExtensionReceiver }` |
| `CompilerPluginRegistrar` | gained an abstract `pluginId` |
| `isData`, `defaultType` | moved |

That's the 2.2→2.4 unified parameter migration. Every one recurs on future bumps.

**`referenceFunctions` is already deprecated in 2.4.10** — the spike uses it, it works, and it's slated for replacement by `finderForBuiltins()`/`finderForSource()`. The plugin would start life with deprecation debt.

**Three call sites need `UnsafeDuringIrConstructionAPI`.** The API is candid about itself.

**Gradle wiring is more work than it looks.** `-Xplugin` via `freeCompilerArgs` silently does nothing — the compile task's `pluginClasspath` is the channel. Shipping to consumers needs a `KotlinCompilerPluginSupportPlugin` as its own published Gradle plugin, carrying `overrideToString` and the opt-out through to the compiler.

## Not verified — each is real work

- **Any target but JVM.** IR is shared so it should carry, but "should" isn't "does".
- **The `@NoDeepPrint` opt-out** isn't honoured by the plugin yet.
- **It overwrites a hand-written `toString()`** as readily as a synthesised one. That's a bug, not a limitation — a real implementation must skip classes that declare their own.

## My read

Tractable, and the delegation design keeps it much smaller than I expected. The cost isn't building it, it's that this project just spent a night escaping a three-year-old toolchain, and a compiler plugin makes every future Kotlin bump a task rather than a version-number change. Worth it if `toString()` override is a headline feature; not worth it if `deepPrint()` at call sites is good enough.